### PR TITLE
make push and deploy token explicit

### DIFF
--- a/python-lib/README.md
+++ b/python-lib/README.md
@@ -52,7 +52,19 @@ You can also choose to publish your package publicly
     PYPI_PUSH_TOKEN: ${{ secrets.PYPI_PUBLIC_API_TOKEN }}
   with:
     public: true
+```
 
+if your package depends on another hosted on our private repo, you will also
+need a *deploy* token for test
+
+```yaml
+- uses: LedgerHQ/actions/python-lib@main
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PYPI_PUSH_TOKEN: ${{ secrets.PYPI_PUSH_TOKEN }}
+    PYPI_DEPLOY_TOKEN: ${{ secrets.PYPI_DEPLOY_TOKEN }}
+  with:
+    public: true
 ```
 
 ## Requirements

--- a/python-lib/action.yml
+++ b/python-lib/action.yml
@@ -17,6 +17,8 @@ runs:
     - uses: LedgerHQ/actions/python-lib/test@main
       with:
         python-version: ${{ inputs.python-version }}
+      env:
+        PYPI_DEPLOY_TOKEN: ${{ env.PYPI_DEPLOY_TOKEN }}
     - uses: LedgerHQ/actions/python-lib/check-version@main
       with:
         python-version: ${{ inputs.python-version }}

--- a/python-lib/test/action.yml
+++ b/python-lib/test/action.yml
@@ -22,8 +22,8 @@ runs:
       uses: pre-commit/action@v2.0.3
     - name: Install dependencies
       run: |
-        pip install --extra-index-url https://${{ env.PYPI_PUSH_TOKEN }}:@pypi.fury.io/ledger -r requirements-dev.txt
-        pip install --extra-index-url https://${{ env.PYPI_PUSH_TOKEN }}:@pypi.fury.io/ledger .[tests]
+        pip install --extra-index-url https://${{ env.PYPI_DEPLOY_TOKEN }}:@pypi.fury.io/ledger -r requirements-dev.txt
+        pip install --extra-index-url https://${{ env.PYPI_DEPLOY_TOKEN }}:@pypi.fury.io/ledger .[tests]
       shell: bash
     - name: Test
       run: |


### PR DESCRIPTION
As per fury.io doc a push token is write only and a deploy token is read
only. We **need** 2 tokens if a package depends on another on fury

Apparently, for a package that do not depends on fury, an empty deploy token is ok