### PR TITLE
Fix: remove package publishment with CI_BOT

### DIFF
--- a/python-app/docker/action.yml
+++ b/python-app/docker/action.yml
@@ -58,8 +58,8 @@ runs:
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
-        username: ${{ env.CI_BOT_USERNAME }}
-        password: ${{ env.CI_BOT_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Build and push


### PR DESCRIPTION
### What is it about ? 

- Following https://ledgerhq.atlassian.net/wiki/spaces/PE/pages/2838823402/Docker+image+delivery+using+GitHub+Container+Registry
We want to publish packages with GITHUB_TOKEN instead of CI_BOT to avoid having right issue.