### PR TITLE
[BUGFIX] Fix GITHUB_TOKEN not available.

### DIFF
--- a/python-app/docker/action.yml
+++ b/python-app/docker/action.yml
@@ -59,7 +59,7 @@ runs:
       with:
         registry: ghcr.io
         username: ${{ env.CI_BOT_USERNAME || github.actor }}
-        password: ${{ env.CI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        password: ${{ env.CI_BOT_TOKEN || github.token }}
 
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Build and push


### PR DESCRIPTION
The secrets are not passed through the actions, so we need to directly
use the context, which is available.