### PR TITLE
Auto publish python libs feature branches

### DIFF
--- a/gemfury/latest-version/action.yml
+++ b/gemfury/latest-version/action.yml
@@ -2,6 +2,9 @@ name: "Get latest package version"
 description: "Get latest package version from gemfury"
 
 inputs:
+  package-name:
+    description: "Name of the package"
+    required: true
   feature-name:
     description: "Name of the feature to target"
     required: false
@@ -23,12 +26,13 @@ runs:
       run: |
         feature_name=${{ inputs.feature-name }}
         if [[ -n "${feature_name}" ]]; then
-          dotted_feature_name=${feature_name//-/.}
+          dotted_feature_name=${feature_name//[-_]/.}
           grep_filter="rc[0-9]+\+${dotted_feature_name}"
         fi
 
         # This `versions` command can only be executed by a PYPI_FULL_ACCESS_TOKEN
-        last_version=$(fury versions --api-token=${{ env.FULL_ACCESS_TOKEN }} vault-proto | grep -E ".*${grep_filter}" | head -n 1 | awk '{print $1}')
+        matching_versions=$((fury versions --api-token=${{ env.FULL_ACCESS_TOKEN }} ${{ inputs.package-name }} | grep -E ".*${grep_filter}") || echo "")
+        last_version=$(echo $matching_versions | awk '{print $1}')
         echo "::set-output name=last-version::${last_version}"
 
         if [[ -n "${feature_name}" ]]; then

--- a/gemfury/latest-version/action.yml
+++ b/gemfury/latest-version/action.yml
@@ -6,12 +6,20 @@ inputs:
     description: "Name of the feature to target"
     required: false
     default: ""
+outputs:
+  last-version:
+    description: "Last version found of the package"
+    value: ${{ steps.version.outputs.last-version }}
+  next-feature-tag:
+    description: "Next feature flag to use"
+    value: ${{ steps.version.outputs.next-feature-tag }}
 
 runs:
   using: "composite"
   steps:
     - uses: LedgerHQ/actions/gemfury/install@main
     - name: Get version data
+      id: version
       run: |
         feature_name=${{ inputs.feature-name }}
         if [[ -n "${feature_name}" ]]; then
@@ -28,7 +36,10 @@ runs:
           last_version=${last_version%+*}
           # remove everything before and including rc
           last_rc_number=${last_version#*rc}
-          feature_tag="rc$((last_rc_number+1))+${feature_name}"
-          echo "::set-output name=next-feature-tag::${feature_tag}"
+          next_feature_tag="rc$((last_rc_number+1))+${feature_name}"
+          echo "::set-output name=next-feature-tag::${next_feature_tag}"
         fi
+      shell: bash
+    - name: Display output
+      run: echo "${{ toJson(steps.version.outputs) }}"
       shell: bash

--- a/gemfury/latest-version/action.yml
+++ b/gemfury/latest-version/action.yml
@@ -19,6 +19,7 @@ runs:
           grep_filter="rc[0-9]+\+${dotted_feature_name}"
         fi
 
+        # This `versions` command can only be executed by a PYPI_FULL_ACCESS_TOKEN
         last_version=$(fury versions --api-token=${{ env.FULL_ACCESS_TOKEN }} vault-proto | grep -E ".*${grep_filter}" | head -n 1 | awk '{print $1}')
         echo "::set-output name=last-version::${last_version}"
 

--- a/gemfury/publish/action.yml
+++ b/gemfury/publish/action.yml
@@ -9,5 +9,5 @@ runs:
         python setup.py sdist
         package_file=$(find dist -type f -name "*.tar.gz")
         echo "Publishing package: ${package_file}"
-        curl -F package=@${package_file} https://${{ env.DEPLOY_TOKEN }}@push.fury.io/ledger/
+        curl --fail -F package=@${package_file} https://${{ env.DEPLOY_TOKEN }}@push.fury.io/ledger/
       shell: bash

--- a/gemfury/publish/action.yml
+++ b/gemfury/publish/action.yml
@@ -6,8 +6,10 @@ runs:
   steps:
     - name: Push to GemFury
       run: |
-        python setup.py sdist
         package_file=$(find dist -type f -name "*.tar.gz")
+        if [[ "$package_file" == "" ]]; then
+          package_file=$(find dist -type f -name "*.whl")
+        fi
         echo "Publishing package: ${package_file}"
-        curl --fail -F package=@${package_file} https://${{ env.DEPLOY_TOKEN }}@push.fury.io/ledger/
+        curl --fail -F package=@${package_file} https://${{ env.PUSH_TOKEN }}@push.fury.io/ledger/
       shell: bash

--- a/python-lib/README.md
+++ b/python-lib/README.md
@@ -67,6 +67,19 @@ need a *deploy* token for test
     public: true
 ```
 
+If you want your feature branches to be published as rc versions on gemfury, you
+will need to provide a `PYPI_FULL_ACCESS_TOKEN`, required to be able to fetch
+existing versions of packages on gemfury:
+
+```yaml
+- uses: LedgerHQ/actions/python-lib@main
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PYPI_FULL_ACCESS_TOKEN: ${{ secrets.PYPI_FULL_ACCESS_TOKEN }}
+  with:
+    public: true
+```
+
 ## Requirements
 
 Beside chosing the version of python to run, this action does not allow the
@@ -78,6 +91,7 @@ a few conditions to use this action:
 - Use `main` as your base branch.
 - Don't rely on `pipenv` for listing and locking deps. We want `pipenv` to
 be used by services, and simple `setup.py` + `requirements.txt` for libs.
+- Define your version in `setup.py` as a variable `__version__ = "1.2.3"`
 - If you have multiple extra requirement sets, define a `tests` set which
 combines all your deps (see [this example](https://github.com/LedgerHQ/python-ledgercommon/blob/main/setup.py#L35)).
 Essentially running `pip install .[tests]` should install all the lib deps

--- a/python-lib/action.yml
+++ b/python-lib/action.yml
@@ -19,6 +19,7 @@ runs:
         python-version: ${{ inputs.python-version }}
       env:
         PYPI_DEPLOY_TOKEN: ${{ env.PYPI_DEPLOY_TOKEN }}
+        PYPI_FULL_ACCESS_TOKEN: ${{ env.PYPI_FULL_ACCESS_TOKEN }}
     - uses: LedgerHQ/actions/python-lib/check-version@main
       with:
         python-version: ${{ inputs.python-version }}
@@ -29,3 +30,4 @@ runs:
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         PYPI_PUSH_TOKEN: ${{ env.PYPI_PUSH_TOKEN }}
+        PYPI_FULL_ACCESS_TOKEN: ${{ env.PYPI_FULL_ACCESS_TOKEN }}

--- a/python-lib/action.yml
+++ b/python-lib/action.yml
@@ -9,7 +9,7 @@ inputs:
   public:
     description: "if true, push to public python package index pypi.org, otherwise use our private fury.io"
     required: false
-    default: false
+    default: "false"
 
 runs:
   using: "composite"

--- a/python-lib/publish/action.yml
+++ b/python-lib/publish/action.yml
@@ -34,17 +34,15 @@ runs:
         FULL_ACCESS_TOKEN: ${{ env.PYPI_FULL_ACCESS_TOKEN }}
     - name: Set env vars
       run: |
-        publish_feature="false"
         if [[ -n "${{ steps.fury.outputs.next-feature-tag }}" ]];
-          if [[ $(grep -E '__version__ = ".+"' setup.py) ]]; then
+          if [[ $(grep -E ' +version=".+",' setup.py | wc -l) == 1 ]]; then
             echo "Temporarily updating version with feature tag ${{ steps.fury.outputs.next-feature-tag }}."
-            sed -i 's/__version__ = "\(.\+\)"/__version__ = "\1${{ steps.fury.outputs.next-feature-tag }}"/' setup.py
-            publish_feature="true"
+            sed -i 's/\( \+\)version="\(.\+\)",/\1version="\2${{ steps.fury.outputs.next-feature-tag }}",/' setup.py
           else
-            echo "Can't find __version__ to update, skipping feature publish."
+            echo "Can't find a version to update in setup.py"
+            exit 1
           fi
         fi
-        echo "PUBLISH_FEATURE=${publish_feature}" >> $GITHUB_ENV
         echo "RELEASE_NAME=$(python setup.py --fullname)" >> $GITHUB_ENV
       shell: bash
     - name: Create Release
@@ -55,12 +53,14 @@ runs:
       with:
         tag_name: ${{ env.RELEASE_NAME }}
         release_name: ${{ env.RELEASE_NAME }}
+    - name: Build dist
+      run: python setup.py sdist
+      shell: bash
     - name: Push to GemFury
-      if: ${{ inputs.public == 'false' && github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/main') || env.PUBLISH_FEATURE == 'true') }}
+      if: ${{ inputs.public == 'false' && github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/main') || steps.fury.outputs.next-feature-tag != '' }}
       uses: LedgerHQ/actions/gemfury/publish
       env:
-        DEPLOY_TOKEN: ${{ env.PYPI_PUSH_TOKEN || env.PYPI_FULL_ACCESS_TOKEN }}
-      shell: bash
+        PUSH_TOKEN: ${{ env.PYPI_PUSH_TOKEN || env.PYPI_FULL_ACCESS_TOKEN }}
     - name: Push to Pypi
       if: ${{ inputs.public == 'true' && startsWith(github.ref, 'refs/heads/main') && github.event_name == 'push' }}
       env:

--- a/python-lib/publish/action.yml
+++ b/python-lib/publish/action.yml
@@ -9,7 +9,7 @@ inputs:
   public:
     description: "if true, push to public python package index pypi.org, otherwise use our private fury.io"
     required: false
-    default: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -45,7 +45,7 @@ runs:
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ env.PYPI_PUSH_TOKEN  }}
-        TWINE_NON_INTERACTIVE: 1
+        TWINE_NON_INTERACTIVE: "1"
       run: |
         python3 -m pip install --upgrade build twine
         python3 -m build

--- a/python-lib/publish/action.yml
+++ b/python-lib/publish/action.yml
@@ -26,7 +26,7 @@ runs:
         echo "::set-output name=feature-name::${ref#refs/heads/feature/}"
       shell: bash
     - uses: LedgerHQ/actions/gemfury/latest-version
-      if: ${{ inputs.public == 'false' && startsWith(github.ref, 'refs/heads/feature/') }}
+      if: ${{ inputs.public == 'false' && startsWith(github.ref, 'refs/heads/feature/') && env.PYPI_FULL_ACCESS_TOKEN != '' }}
       id: fury
       with:
         feature-name: ${{ steps.feature.outputs.feature-name }}
@@ -59,13 +59,13 @@ runs:
       if: ${{ inputs.public == 'false' && github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/main') || env.PUBLISH_FEATURE == 'true') }}
       uses: LedgerHQ/actions/gemfury/publish
       env:
-        DEPLOY_TOKEN: ${{ env.PYPI_PUSH_TOKEN }}
+        DEPLOY_TOKEN: ${{ env.PYPI_PUSH_TOKEN || env.PYPI_FULL_ACCESS_TOKEN }}
       shell: bash
     - name: Push to Pypi
       if: ${{ inputs.public == 'true' && startsWith(github.ref, 'refs/heads/main') && github.event_name == 'push' }}
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ env.PYPI_PUSH_TOKEN  }}
+        TWINE_PASSWORD: ${{ env.PYPI_PUSH_TOKEN || env.PYPI_FULL_ACCESS_TOKEN }}
         TWINE_NON_INTERACTIVE: "1"
       run: |
         python3 -m pip install --upgrade build twine

--- a/python-lib/publish/action.yml
+++ b/python-lib/publish/action.yml
@@ -18,8 +18,33 @@ runs:
     - uses: actions/setup-python@v2
       with:
         python-version: ${{ inputs.python-version }}
+    - name: Get feature branch name
+      if: ${{ startsWith(github.ref, 'refs/heads/feature/') }}
+      id: feature
+      run: |
+        ref="${{ github.ref }}"
+        echo "::set-output name=feature-name::${ref#refs/heads/feature/}"
+      shell: bash
+    - uses: LedgerHQ/actions/gemfury/latest-version
+      if: ${{ inputs.public == 'false' && startsWith(github.ref, 'refs/heads/feature/') }}
+      id: fury
+      with:
+        feature-name: ${{ steps.feature.outputs.feature-name }}
+      env:
+        FULL_ACCESS_TOKEN: ${{ env.PYPI_FULL_ACCESS_TOKEN }}
     - name: Set env vars
       run: |
+        publish_feature="false"
+        if [[ -n "${{ steps.fury.outputs.next-feature-tag }}" ]];
+          if [[ $(grep -E '__version__ = ".+"' setup.py) ]]; then
+            echo "Temporarily updating version with feature tag ${{ steps.fury.outputs.next-feature-tag }}."
+            sed -i 's/__version__ = "\(.\+\)"/__version__ = "\1${{ steps.fury.outputs.next-feature-tag }}"/' setup.py
+            publish_feature="true"
+          else
+            echo "Can't find __version__ to update, skipping feature publish."
+          fi
+        fi
+        echo "PUBLISH_FEATURE=${publish_feature}" >> $GITHUB_ENV
         echo "RELEASE_NAME=$(python setup.py --fullname)" >> $GITHUB_ENV
       shell: bash
     - name: Create Release
@@ -31,14 +56,10 @@ runs:
         tag_name: ${{ env.RELEASE_NAME }}
         release_name: ${{ env.RELEASE_NAME }}
     - name: Push to GemFury
-      if: ${{ inputs.public == 'false' && startsWith(github.ref, 'refs/heads/main') && github.event_name == 'push' }}
+      if: ${{ inputs.public == 'false' && github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/main') || env.PUBLISH_FEATURE == 'true') }}
+      uses: LedgerHQ/actions/gemfury/publish
       env:
         DEPLOY_TOKEN: ${{ env.PYPI_PUSH_TOKEN }}
-      run: |
-        python setup.py sdist
-        package_file="dist/${{ env.RELEASE_NAME }}.tar.gz"
-        echo "Publishing package: ${package_file}"
-        curl -F package=@${package_file} https://${{ env.DEPLOY_TOKEN }}@push.fury.io/ledger/
       shell: bash
     - name: Push to Pypi
       if: ${{ inputs.public == 'true' && startsWith(github.ref, 'refs/heads/main') && github.event_name == 'push' }}

--- a/python-lib/publish/action.yml
+++ b/python-lib/publish/action.yml
@@ -18,23 +18,25 @@ runs:
     - uses: actions/setup-python@v2
       with:
         python-version: ${{ inputs.python-version }}
-    - name: Get feature branch name
-      if: ${{ startsWith(github.ref, 'refs/heads/feature/') }}
+    - name: Get repo details
+      if: ${{ inputs.public == 'false' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/feature/') }}
       id: feature
       run: |
         ref="${{ github.ref }}"
+        echo "::set-output name=package-name::$(python setup.py --name)"
         echo "::set-output name=feature-name::${ref#refs/heads/feature/}"
       shell: bash
-    - uses: LedgerHQ/actions/gemfury/latest-version
-      if: ${{ inputs.public == 'false' && startsWith(github.ref, 'refs/heads/feature/') && env.PYPI_FULL_ACCESS_TOKEN != '' }}
+    - uses: LedgerHQ/actions/gemfury/latest-version@main
+      if: ${{ inputs.public == 'false' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/feature/') }}
       id: fury
       with:
+        package-name: ${{ steps.feature.outputs.package-name }}
         feature-name: ${{ steps.feature.outputs.feature-name }}
       env:
         FULL_ACCESS_TOKEN: ${{ env.PYPI_FULL_ACCESS_TOKEN }}
-    - name: Set env vars
+    - name: Set release name env var
       run: |
-        if [[ -n "${{ steps.fury.outputs.next-feature-tag }}" ]];
+        if [[ -n "${{ steps.fury.outputs.next-feature-tag }}" ]]; then
           if [[ $(grep -E ' +version=".+",' setup.py | wc -l) == 1 ]]; then
             echo "Temporarily updating version with feature tag ${{ steps.fury.outputs.next-feature-tag }}."
             sed -i 's/\( \+\)version="\(.\+\)",/\1version="\2${{ steps.fury.outputs.next-feature-tag }}",/' setup.py
@@ -46,7 +48,7 @@ runs:
         echo "RELEASE_NAME=$(python setup.py --fullname)" >> $GITHUB_ENV
       shell: bash
     - name: Create Release
-      if: ${{ startsWith(github.ref, 'refs/heads/main') && github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main') }}
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
@@ -54,11 +56,12 @@ runs:
         tag_name: ${{ env.RELEASE_NAME }}
         release_name: ${{ env.RELEASE_NAME }}
     - name: Build dist
+      if: ${{ inputs.public == 'false' && github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/main') || steps.fury.outputs.next-feature-tag != '') }}
       run: python setup.py sdist
       shell: bash
     - name: Push to GemFury
-      if: ${{ inputs.public == 'false' && github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/main') || steps.fury.outputs.next-feature-tag != '' }}
-      uses: LedgerHQ/actions/gemfury/publish
+      if: ${{ inputs.public == 'false' && github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/main') || steps.fury.outputs.next-feature-tag != '') }}
+      uses: LedgerHQ/actions/gemfury/publish@main
       env:
         PUSH_TOKEN: ${{ env.PYPI_PUSH_TOKEN || env.PYPI_FULL_ACCESS_TOKEN }}
     - name: Push to Pypi

--- a/python-lib/test/action.yml
+++ b/python-lib/test/action.yml
@@ -22,8 +22,8 @@ runs:
       uses: pre-commit/action@v2.0.3
     - name: Install dependencies
       run: |
-        pip install --extra-index-url https://${{ env.PYPI_DEPLOY_TOKEN }}:@pypi.fury.io/ledger -r requirements-dev.txt
-        pip install --extra-index-url https://${{ env.PYPI_DEPLOY_TOKEN }}:@pypi.fury.io/ledger .[tests]
+        pip install --extra-index-url https://${{ env.PYPI_DEPLOY_TOKEN || env.PYPI_FULL_ACCESS_TOKEN }}:@pypi.fury.io/ledger -r requirements-dev.txt
+        pip install --extra-index-url https://${{ env.PYPI_DEPLOY_TOKEN || env.PYPI_FULL_ACCESS_TOKEN }}:@pypi.fury.io/ledger .[tests]
       shell: bash
     - name: Test
       run: |


### PR DESCRIPTION
As described in https://ledgerhq.atlassian.net/wiki/spaces/VAUL/pages/3639115871/2022-04-12+-+Publish+dev+version+of+python+package we want our python packages to be published as RCs when we push to a feature branch.

The versioning model for these publishes is `<major>.<minor>.<patch>rc<number>+<name.of.the.feature>`.

In this proposal, the publishing is automatic for any `feature/X` branch. The rc number is automatically computed by fetching the last rc and incrementing it. The dev does not have to do any version change manually.

This has required:
- the usage of a new PYPI token, `PYPI_FULL_ACCESS_TOKEN` which allows listing package versions
- forcing a standardised definition of the version in `setup.py` to be able to script its temporary update.

Note that we could alternatively have the devs modify the version in their `setup.py` manually to something like `<major>.<minor>.<patch>rc<number>` and try to publish any version matching this `rc` pattern. A bit more manual, but probably simpler to track.