### PR TITLE
Lowercasing the filter for existing package name

### DIFF
--- a/gemfury/latest-version/action.yml
+++ b/gemfury/latest-version/action.yml
@@ -27,7 +27,7 @@ runs:
         feature_name=${{ inputs.feature-name }}
         if [[ -n "${feature_name}" ]]; then
           dotted_feature_name=${feature_name//[-_]/.}
-          grep_filter="rc[0-9]+\+${dotted_feature_name}"
+          grep_filter=$(echo "rc[0-9]+\+${dotted_feature_name}" | tr '[:upper:]' '[:lower:]')
         fi
 
         # This `versions` command can only be executed by a PYPI_FULL_ACCESS_TOKEN


### PR DESCRIPTION
when checking for existing package on gemfury the package name still had uppercase letters when we seem to push the package with only lowercase letters
so the filter is now updated to lowecarse the package name

source:

Package name generated by the CI and used for searching existing version
![Screenshot 2022-05-12 at 16 26 53](https://user-images.githubusercontent.com/96075716/168098575-80d001d7-d07b-48de-af42-34066e43afe8.png)


name of the package on gemfury
![Screenshot from 2022-05-12 15-34-50](https://user-images.githubusercontent.com/96075716/168097958-f044e765-240e-40e7-8700-ab9ddd510903.png)

