### PR TITLE
VG-3365 Option to force ignore Mypy

### DIFF
--- a/python-app/action.yml
+++ b/python-app/action.yml
@@ -14,6 +14,11 @@ inputs:
     required: false
     default: ""
 
+  ignore-mypy:
+    description: "Force ignoring Mypy step"
+    required: false
+    default: "false"
+
   docker-build-args:
     description: "args to pass to docker build"
     required: false
@@ -27,6 +32,7 @@ runs:
     - uses: LedgerHQ/actions/python-app/test@main
       with:
         src-path: ${{ inputs.src-path }}
+        ignore-mypy: ${{ inputs.ignore-mypy }}
 
     - uses: LedgerHQ/actions/python-app/goss@main
       with:

--- a/python-app/test/action.yml
+++ b/python-app/test/action.yml
@@ -22,6 +22,10 @@ runs:
 
     - name: Optionally run mypy
       run: |
+        if [[ "${{ inputs.ignore-mypy }}" == "true" ]]; then
+          echo "Ignoring Mypy as specified in action inputs"
+          exit 0
+        fi
         if $(pipenv run python -c "import mypy" 2> /dev/null); then
           echo "run mypy on ${SRC}"
           pipenv run mypy --install-types --non-interactive ${SRC}


### PR DESCRIPTION
The `test` action is checking if `mypy` lib is installed on the repo and assume that we want to run Mypy on the codebase then. But that's wrong, in some cases Mypy is just installed because dependency shit hell, and is not properly configured on the project, which makes the mypy fails.

This PR adds a new input flag to allow forcing bypassing the mypy step.