### PR TITLE
VG-7914 Greping the first tag that respects correct release format

### DIFF
--- a/python-app/docker/action.yml
+++ b/python-app/docker/action.yml
@@ -29,7 +29,10 @@ runs:
       run: |
         # lowercase image name
         echo IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
-        echo VERSION=$(git describe --tags) >> $GITHUB_ENV
+        # fetching all tags, latest on top
+        git tag --sort=-authordate >> tags$
+        # getting the first one that's <number>.<unmber>.<number>
+        echo VERSION=$(grep -m 1 '^[0-9]*\.[0-9]*\.[0-9]*$' tags) >> $GITHUB_ENV
       shell: bash
 
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}


### PR DESCRIPTION
Before it was the latest tag that was found that was used
`git describe --tags`
Now we retrieve the list of all tags and order them from latest to oldest, and grep only the first one that matches the release format, so
`<number>.<number>.<number>`, examples: `7.12.3 or 1.5.0`
meaning `<number>.<number>.<number>-rc*` won't get used as release tags anymore