### PR TITLE
Update action.yaml

### DIFF
--- a/ec2-linux-runner/action.yaml
+++ b/ec2-linux-runner/action.yaml
@@ -88,12 +88,12 @@ runs:
   steps:
     - id: random-number-generator
       if: inputs.mode == 'start'
-      run: echo "::set-output name=random-id::$(echo $RANDOM)"
+      run: echo "random-id=$(echo $RANDOM)" >> $GITHUB_OUTPUT
       shell: bash
 
     - id: get-ami-id
       if: inputs.mode == 'start'
-      run: echo "::set-output name=ami-id::$(aws ec2 describe-images --filters 'Name=name,Values=${{ inputs.ami-name-filter }}' --query 'Images[*].ImageId' --output text)"
+      run: echo "ami-id=$(aws ec2 describe-images --filters 'Name=name,Values=${{ inputs.ami-name-filter }}' --query 'Images[*].ImageId' --output text)" >> $GITHUB_OUTPUT
       shell: bash
 
     - id: start-ec2-runner


### PR DESCRIPTION
addressing the warning messages we have for using the old `set-output` method

<img width="1083" alt="CleanShot 2023-01-19 at 12 04 57@2x" src="https://user-images.githubusercontent.com/671786/213426612-3298a7df-891c-4ff6-90ad-b6166a0897b7.png">

For context: 
https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs#example-defining-outputs-for-a-job
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/