### PR TITLE
feature: decomission codecov

### DIFF
--- a/python-lib/test/action.yml
+++ b/python-lib/test/action.yml
@@ -43,5 +43,4 @@ runs:
         else
             echo "mypy not installed, skipping";
         fi
-        codecov
       shell: bash


### PR DESCRIPTION
Blocking some pipelines as CODECOV_TOKEN is not passed to the action and official codecov action is not used
https://github.com/LedgerHQ/python-smart-contract/actions/runs/4057321835/jobs/6999723239#step:2:886

Related issue on codecov tracker: https://github.com/codecov/codecov-action/issues/557