### PR TITLE
Redocly/lint and branches

### DIFF
--- a/python-app/doc/action.yml
+++ b/python-app/doc/action.yml
@@ -35,5 +35,5 @@ runs:
 
     - if: ${{ steps.check-doc.outputs.is-doc-needed == 'true' }}
       name: Publish to redocly
-      run: npx @redocly/openapi-cli@latest push doc/api-spec.yaml "${{ inputs.redocly-project }}"
+      run: npx @redocly/cli@latest push doc/api-spec.yaml "${{ inputs.redocly-project }}"
       shell: bash

--- a/redocly/lint/README.md
+++ b/redocly/lint/README.md
@@ -1,0 +1,17 @@
+# redocly/lint
+
+Github action linting an OpenAPI specification using redocly CLI.
+
+## Action usage
+
+```yaml
+- uses: LedgerHQ/actions/redocly/lint@main
+  with:
+    specs: path/to/openapi.json
+```
+
+You can fine-tune the linter by providing a [Redocly configuration](https://redocly.com/docs/cli/configuration/) in the repository.
+
+## Contribute
+
+Open a PR to contribute, the CI and reviewer will take care of the rest.

--- a/redocly/lint/action.yml
+++ b/redocly/lint/action.yml
@@ -1,0 +1,22 @@
+name: "Lint OpenAPI"
+description: "Lint OpenAPI specifications using Redocly CLI"
+
+inputs:
+  specs:
+    description: "Path to the OpenAPI specifications to lint"
+    required: true
+    default: openapi.json
+
+runs:
+  using: "composite"
+  steps:
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14
+    - name: Lint OpenAPI specifications
+      run: npx @redocly/cli@latest lint ${{ inputs.specs }}
+      shell: bash
+    - name: Gives some statistics about these OpenAPI specifications
+      run: npx @redocly/cli@latest stats ${{ inputs.specs }}
+      shell: bash

--- a/redocly/publish/README.md
+++ b/redocly/publish/README.md
@@ -20,6 +20,13 @@ If your spec is located elsewhere you can
     spec-path: "account-reader/tooling/openapi/spec.json"
 ```
 
+By default we publish the spec at the path to the `main` branch.
+If you want to publish to a custom branchm provide the `branch` parameter:
+
+```yaml
+    branch: "feature/test"
+```
+
 ## Contribute
 
 Open a PR to contribute, the CI and reviewer will take care of the rest.

--- a/redocly/publish/action.yml
+++ b/redocly/publish/action.yml
@@ -12,6 +12,10 @@ inputs:
   api-version:
     description: "Version of the API to publish on"
     required: true
+  branch:
+    description: "Branch to publish on"
+    required: true
+    default: "main" # The CLI default
 
 runs:
   using: "composite"
@@ -24,7 +28,7 @@ runs:
       env:
         REDOCLY_AUTHORIZATION: ${{ env.REDOCLY_AUTHORIZATION }}
       run: |
-        npx @redocly/openapi-cli@latest push ${{ inputs.spec-path }} "@ledger/${{ inputs.api-name }}@${{ inputs.api-version }}" > output
+        npx @redocly/cli@latest push ${{ inputs.spec-path }} "@ledger/${{ inputs.api-name }}@${{ inputs.api-version }} --branch "{{ inputs.branch }}" > output
         # The redocly tool does not provide a simple way to know if it has succeeded or not.
         # We have to grep its output.
         if [[ $(grep "is successfully pushed to Redocly API Registry" output) ]]; then


### PR DESCRIPTION
This PR 
- updates the redocly cli package name (from the deprecated`@redocly/openapi-cli` to `@redocly/cli`)
- adds an optional `branch` parameter to the `publish` action (defaulting to `main` as the cli is)
- adds a `redocly/lint` action which is linting and providing statistics using the same redocly cli