### PR TITLE
fix(python-app/doc): add the missing but required `shell` property

### DIFF
--- a/python-app/doc/action.yml
+++ b/python-app/doc/action.yml
@@ -37,6 +37,7 @@ runs:
         VERSION=$(echo "${{ inputs.redocly-project }}" | cut cut -d'@' -f3)
         echo "name=${NAME}" >> $GITHUB_OUTPUT
         echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      shell: bash
     
     - if: ${{ steps.check-doc.outputs.is-doc-needed == 'true' }}
       uses: LedgerHQ/actions/redocly/publish@main


### PR DESCRIPTION
This PR fixes the `python-app/doc` action: adds the missing but required `shell` property, even if the doc says it is optional