### PR TITLE
fix(redocly): fix some redocly typos

### DIFF
--- a/redocly/publish/action.yml
+++ b/redocly/publish/action.yml
@@ -29,7 +29,7 @@ runs:
       env:
         REDOCLY_AUTHORIZATION: ${{ env.REDOCLY_AUTHORIZATION }}
       run: |
-        npx @redocly/cli@latest push ${{ inputs.spec-path }} "@ledger/${{ inputs.api-name }}@${{ inputs.api-version }}" --branch "{{ inputs.branch }}" > output
+        npx @redocly/cli@latest push ${{ inputs.spec-path }} "@ledger/${{ inputs.api-name }}@${{ inputs.api-version }}" --branch "${{ inputs.branch }}" > output
         # The redocly tool does not provide a simple way to know if it has succeeded or not.
         # We have to grep its output.
         if [[ $(grep "is successfully pushed to Redocly API Registry" output) ]]; then


### PR DESCRIPTION
Just a fixed some typos in redocly publish workflow:
- a missing dollar sign (var is currently not extrapolated)