### PR TITLE
fix(python-app): name compatibility with redocly action

### DIFF
--- a/python-app/doc/action.yml
+++ b/python-app/doc/action.yml
@@ -44,4 +44,4 @@ runs:
       with:
         api-name: ${{ steps.redocly-metadata.outputs.name }}
         api-version: ${{ steps.redocly-metadata.outputs.version }}
-        api-spec: doc/api-spec.yaml
+        spec-path: doc/api-spec.yaml


### PR DESCRIPTION
 * Should match this parameter name : https://github.com/LedgerHQ/actions/blob/main/redocly/publish/action.yml#L5