### PR TITLE
feat: add new action to publish test results to allure

### DIFF
--- a/.github/workflows/allure.yml
+++ b/.github/workflows/allure.yml
@@ -1,0 +1,22 @@
+name: Test allure action
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ allure/** ]
+  pull_request:
+    branches: [ main ]
+    paths: [ allure/** ]
+
+defaults:
+  run:
+    working-directory: allure
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Test new version of the action
+        run: echo "Nothing to do"

--- a/allure/publish/README.md
+++ b/allure/publish/README.md
@@ -1,0 +1,29 @@
+# allure/publish
+
+Publish allure results on an allure server, and notify of results on slack.
+
+## Requirements
+
+For slack notifications:
+
+- You'll need to have a template file in `.github/templates/slack.json`, see [this example](https://github.com/LedgerHQ/vault-e2e-tests/blob/main/.github/templates/slack.json) from the QAA team.
+- If you don't use a self-hosted, you'll need to install [the allure npm package](https://www.npmjs.com/package/allure-commandline) as well as `jq`.
+
+## Action usage
+
+```yaml
+- uses: LedgerHQ/actions/allure/publish@main
+  if: always()
+  with:
+    allure-username: ${{ secrets.ALLURE_SERVER_USERNAME }}
+    allure-password: ${{ secrets.ALLURE_SERVER_PASSWORD }}
+    slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+If you don't want to push a notification on Slack, you can skip `slack-webhook-url`.
+
+See the [action's content](action.yml) for additional available parameters.
+
+## Contribute
+
+Open a PR to contribute, the CI and reviewer will take care of the rest.

--- a/allure/publish/action.yml
+++ b/allure/publish/action.yml
@@ -1,0 +1,72 @@
+name: "Publish allure"
+description: "Publish allure report and notify on slack"
+
+inputs:
+  allure-username:
+    description: "Allure username"
+    required: true
+  allure-password:
+    description: "Allure password"
+    required: true
+  allure-results-path:
+    description: "Path to the folder containing the `allure-results` folder"
+    required: false
+    default: "."
+  slack-title:
+    description: Title to use for the slack notification
+    required: false
+    default: ""
+  slack-webhook-url:
+    description: URL for slack notification
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Upload Allure Report
+      uses: actions/upload-artifact@v3
+      with:
+        name: "allure-results"
+        path: ${{ inputs.allure-results-path }}/allure-results
+    - name: Publish report on Allure Server
+      id: allure-server
+      uses: LedgerHQ/send-to-allure-server-action@2.0.0
+      with:
+        allure-server-url: "https://allure-server.aws.prd.ldg-tech.com"
+        build-name: ${{ github.workflow }}
+        build-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        username: ${{ inputs.allure-username }}
+        password: ${{ inputs.allure-password }}
+        path: ${{ github.repository }}
+        allure-results: ${{ inputs.allure-results-path }}/allure-results
+    - name: Get summary
+      if: inputs.slack-webhook-url
+      run: |
+        cd ${{ inputs.allure-results-path }}
+        allure generate
+        cd allure-report/widgets
+        passedTests=$(jq '.statistic.passed' summary.json)
+        failedTests=$(jq '.statistic.failed' summary.json)
+        brokenTests=$(jq '.statistic.broken' summary.json)
+        skippedTests=$(jq '.statistic.skipped' summary.json)
+        totalTests=$(jq '.statistic.total' summary.json)
+        echo "TEST_RESULT=$passedTests passed, $failedTests failed, $brokenTests broken, $skippedTests skipped, $totalTests total" >> $GITHUB_ENV
+        if [[ "$failedTests" == "0" ]]; then
+          echo "STATUS_COLOR=good" >> $GITHUB_ENV;
+        else
+          echo "STATUS_COLOR=danger" >> $GITHUB_ENV;
+        fi
+      shell: bash
+    - name: Send notification to Slack
+      if: inputs.slack-webhook-url
+      uses: LedgerHQ/slack-action@v1.5
+      env:
+        SLACK_WEBHOOK: ${{ inputs.slack-webhook-url }}
+      with:
+        template: "./.github/templates/slack.json"
+        color: ${{ env.STATUS_COLOR }}
+        title: ${{ inputs.slack-title || format('{0}/{1}', github.repository, github.run_id) }}
+        summary: ${{ env.TEST_RESULT || 'No test results' }}
+        report_url: ${{ steps.allure-server.outputs.report-url }}
+        report_path: ${{ github.repository }}


### PR DESCRIPTION
Adding a new action to compile and push allure test results to our allure server.

Based off https://github.com/LedgerHQ/vault-e2e-tests/blob/main/.github/workflows/reusable.yml#L281