### PR TITLE
feat(pdm): add `pdm` actions (VG-14148)

### DIFF
--- a/pdm/README.md
+++ b/pdm/README.md
@@ -1,0 +1,18 @@
+# PDM-related actions
+
+Provides some reusable PDM actions.
+
+## Actions
+
+| Name | Description |
+|--------|-------------|
+| [Documentation (`doc`)](doc/) | Build and publish documentation |
+| [Build Docker Image (`docker`)](docker/) | Build Docker image |
+| [Initialize `pdm` (`init`)](init/) | Install Python and `pdm` with cache and extract metadata |
+| [Lint (`lint`)](lint/) | Lint running pre-commit hooks |
+| [Extract `pdm` metadata (`meta`)](meta/) | Extract required metadata from `pdm` |
+| [Release (`release`)](release/) | Bump version and publish release assets |
+| [Test (`test`)](test/) | Execute test using `pdm` scripts |
+| [Build documentation (`doc/build`)](doc/build/) | Build the documentation using `pdm` commands |
+| [Publish documentation (`doc/publish`)](doc/publish/) | Publish the documentation |
+

--- a/pdm/doc/README.md
+++ b/pdm/doc/README.md
@@ -1,0 +1,33 @@
+# Documentation
+
+Build and publish documentation
+
+## Usage
+
+```yaml
+jobs:
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/pdm/doc@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `version` | Force a version to be built | `""` | `false` |
+| `openapi` | Has OpenAPI specs | `false` | `false` |
+| `site` | Publish a documentation site | `false` | `false` |
+| `pypi-token` | A read token for private PyPI access | `""` | `false` |
+| `init` | Clone & sync | `true` | `false` |
+| `python-version` | Python version used to build | `3.11` | `false` |
+
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `url` | The published documentation URL |
+
+

--- a/pdm/doc/action.yml
+++ b/pdm/doc/action.yml
@@ -1,0 +1,47 @@
+name: Documentation
+description: Build and publish documentation
+
+inputs:
+  version:
+    description: Force a version to be built
+    required: false
+  openapi:
+    description: Has OpenAPI specs
+    default: false
+  site:
+    description: Publish a documentation site
+    default: false
+  pypi-token:
+    description: A read token for private PyPI access
+    required: false
+  init:
+    description: Clone & sync
+    default: true
+  python-version:
+    description: Python version used to build
+    required: false
+    default: "3.11"
+
+outputs:
+  url:
+    description: The published documentation URL
+    value: ${{ steps.publish.outputs.url }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: LedgerHQ/actions/pdm/doc/build@main
+      with:
+        init: ${{ inputs.init }}
+        python-version: ${{ inputs.python-version }}
+        pypi-token: ${{ inputs.pypi-token }}
+        openapi: ${{ inputs.openapi }}
+        site: ${{ inputs.site }}
+    - uses: LedgerHQ/actions/pdm/doc/publish@main
+      id: publish
+      with:
+        init: false
+        pypi-token: ${{ inputs.pypi-token }}
+        openapi: ${{ inputs.openapi }}
+        site: ${{ inputs.site }}
+        version: ${{ inputs.version }}

--- a/pdm/doc/build/README.md
+++ b/pdm/doc/build/README.md
@@ -1,0 +1,29 @@
+# Build documentation
+
+Build the documentation using `pdm` commands
+
+## Usage
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/pdm/doc/build@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `python-version` | Python version used to build | `3.11` | `false` |
+| `pypi-token` | A read token for private PyPI access | `""` | `false` |
+| `openapi` | Whether or not to build OpenAPI specs | `false` | `false` |
+| `site` | Whether or not to build a documentation site | `false` | `false` |
+| `init` | Clone & sync | `true` | `false` |
+
+
+## Outputs
+
+N/A
+

--- a/pdm/doc/build/action.yml
+++ b/pdm/doc/build/action.yml
@@ -1,0 +1,75 @@
+name: Build documentation
+description: Build the documentation using `pdm` commands
+
+inputs:
+  python-version:
+    description: Python version used to build
+    required: false
+    default: "3.11"
+  pypi-token:
+    description: A read token for private PyPI access
+    required: false
+  openapi:
+    description: Whether or not to build OpenAPI specs
+    default: false
+  site:
+    description: Whether or not to build a documentation site
+    default: false
+  init:
+    description: Clone & sync
+    default: true
+
+runs:
+  using: composite
+  steps:
+    - name: Clone and install dependencies
+      uses: LedgerHQ/actions/pdm/init@main
+      if: inputs.init == 'true'
+      with:
+        group: docs
+        history: true
+        pypi-token: ${{ inputs.pypi-token }}
+        python-version: ${{ inputs.python-version }}
+
+    - name: Update the CHANGELOG
+      # Failsafe changelog too avoid failure when there is no update
+      run: pdm changelog || true
+      env:
+        FORCE_COLOR: true
+      shell: bash
+
+    - name: Upload the CHANGELOG
+      uses: actions/upload-artifact@v4
+      with:
+        name: changelog
+        path: CHANGELOG.md
+
+    - name: Generate the OpenAPI specifications
+      if: inputs.openapi == 'true'
+      run: pdm doc:openapi
+      env:
+        FORCE_COLOR: true
+      shell: bash
+
+    - name: Upload the OpenAPI specifications
+      if: inputs.openapi == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: openapi
+        path: docs/openapi.yaml
+
+    - name: Generate the documentation
+      if: inputs.site == 'true'
+      run: pdm doc:build
+      env:
+        FORCE_COLOR: true
+      shell: bash
+      
+    - name: Upload the generated documentation
+      if: inputs.site == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: documentation
+        path: site/
+        retention-days: 7
+        if-no-files-found: error

--- a/pdm/doc/publish/README.md
+++ b/pdm/doc/publish/README.md
@@ -1,0 +1,32 @@
+# Publish documentation
+
+Publish the documentation
+
+## Usage
+
+```yaml
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/pdm/doc/publish@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `version` | Force a version to be built | `""` | `false` |
+| `openapi` | Has OpenAPI specs | `false` | `false` |
+| `site` | Publish a documentation site | `false` | `false` |
+| `pypi-token` | A read token for private PyPI access | `""` | `false` |
+| `init` | Clone & sync | `true` | `false` |
+
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `url` | The published documentation URL |
+
+

--- a/pdm/doc/publish/action.yml
+++ b/pdm/doc/publish/action.yml
@@ -1,0 +1,69 @@
+name: Publish documentation
+description: Publish the documentation
+
+inputs:
+  version:
+    description: Force a version to be built
+    required: false
+  openapi:
+    description: Has OpenAPI specs
+    default: false
+  site:
+    description: Publish a documentation site
+    default: false
+  pypi-token:
+    description: A read token for private PyPI access
+    required: false
+  init:
+    description: Clone & sync
+    default: true
+
+outputs:
+  url:
+    description: The published documentation URL
+    value: ${{ steps.summary.outputs.url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Clone and install dependencies
+      if: inputs.init == 'true'
+      uses: LedgerHQ/actions/pdm/init@main
+      with:
+        group: docs
+        history: true
+        pypi-token: ${{ inputs.pypi-token }}
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: changelog
+    
+    - uses: actions/download-artifact@v4
+      if: inputs.openapi == 'true'
+      with:
+        name: openapi
+        path: docs
+
+    - name: Deploy the documentation site (main)
+      if: inputs.site == 'true' && github.ref == 'refs/heads/main'
+      run: pdm doc:deploy --push --update-aliases main latest
+      env:
+        FORCE_COLOR: true
+      shell: bash
+
+    - name: Deploy the documentation site (tag)
+      if: inputs.site == 'true' && inputs.version || startsWith(github.ref, 'refs/tags')
+      run: pdm doc:deploy --push ${{ inputs.version || github.head_ref || github.ref_name }}
+      env:
+        FORCE_COLOR: true
+      shell: bash
+
+    - name: Publish summary
+      id: summary
+      if: inputs.site == 'true'
+      run: |
+        version=${{ inputs.version || github.ref == 'refs/heads/main' && 'latest' || github.head_ref || github.ref_name }}
+        url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${version}"
+        echo "url=${url}" >> $GITHUB_OUTPUT
+        echo "📖 A new documentation has been published: ${url}" >> $GITHUB_STEP_SUMMARY
+      shell: bash

--- a/pdm/docker/README.md
+++ b/pdm/docker/README.md
@@ -1,0 +1,31 @@
+# Build Docker Image
+
+Build Docker image
+
+## Usage
+
+```yaml
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/pdm/docker@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `version` | Force the built version | `""` | `false` |
+| `pypi-token` | A Token to Ledger private PyPI with read permissions | `""` | `true` |
+| `github-token` | A Github token with | `""` | `false` |
+
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `image` | The published docker image |
+| `digest` | The published docker image digest |
+
+

--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -1,0 +1,126 @@
+name: Build Docker Image
+description: Build Docker image
+
+inputs:
+  clone:
+    description: Wether to clone or not
+    default: true
+  version:
+    description: Force the built version
+  pypi-token:
+    description: A Token to Ledger private PyPI with read permissions
+    required: true
+  github-token:
+    description: A Github token with 
+
+
+outputs:
+  image:
+    description: The published docker image
+    value: ${{ steps.summary.outputs.image }}
+  digest:
+    description: The published docker image digest
+    value: ${{ steps.summary.outputs.digest }}
+
+runs:
+  using:  composite
+  steps:
+    - name: Clone
+      if: inputs.clone == 'true'
+      uses: actions/checkout@v4
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Compute docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/ledgerhq/${{ github.event.repository.name }}
+        flavor: latest=false
+        tags: |
+          type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+          type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
+          type=pep440,pattern={{major}}
+          type=pep440,pattern={{major}}.{{minor}}
+
+    - name: Compute some variables
+      id: vars
+      run: |
+        VERSION=${{ inputs.version || github.ref_type == 'tag' && github.ref_name || format('0.dev+{0}.{1}', env.DOCKER_METADATA_OUTPUT_VERSION, github.sha) }}
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        [ -f goss.yaml ] && HAS_GOSS='true' || HAS_GOSS='false'
+        echo "has_goss=${HAS_GOSS}" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Display vars output
+      run: echo "${{ toJson(steps.vars.outputs) }}"
+      shell: bash
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github-token }}
+
+    - name: Build docker image
+      if: steps.vars.outputs.has_goss == 'true'
+      uses: docker/build-push-action@v5
+      with:
+        build-args: |
+          VERSION=${{ steps.vars.outputs.version }}
+          DD_GIT_REPOSITORY_URL=github.com/${{ github.repository }}
+          DD_GIT_COMMIT_SHA=${{ github.sha }}
+        secrets: |
+          PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token }}
+        pull: true
+        load: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Install goss
+      uses: e1himself/goss-installation-action@v1.2.1
+      if: steps.vars.outputs.has_goss == 'true'
+
+    - name: Run GOSS validation
+      run: dgoss run ghcr.io/ledgerhq/${{ github.event.repository.name }}:${DOCKER_METADATA_OUTPUT_VERSION}
+      if: steps.vars.outputs.has_goss == 'true'
+      env:
+        # Make dgoss works with Ledger dind runners
+        GOSS_FILES_STRATEGY: cp
+      shell: bash
+
+    - name: Push docker image
+      uses: docker/build-push-action@v5
+      id: docker
+      with:
+        build-args: |
+          VERSION=${{ steps.vars.outputs.version }}
+          DD_GIT_REPOSITORY_URL=github.com/${{ github.repository }}
+          DD_GIT_COMMIT_SHA=${{ github.sha }}
+        secrets: |
+          PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token }}
+        pull: ${{ steps.vars.outputs.has_goss != 'true' }}
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Create Summary
+      id: summary
+      run: |
+        IMAGE="${{ fromJSON(steps.docker.outputs.metadata)['image.name'] }}"
+        IMAGE=${IMAGE##*,}
+        DIGEST="${{ fromJSON(steps.docker.outputs.metadata)['containerimage.digest'] }}"
+        echo "**Image:** \`${IMAGE}\`" >> $GITHUB_STEP_SUMMARY
+        echo "**Digest:** \`${DIGEST}\`" >> $GITHUB_STEP_SUMMARY
+        echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+        echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+      shell: bash

--- a/pdm/init/README.md
+++ b/pdm/init/README.md
@@ -1,0 +1,29 @@
+# Initialize `pdm`
+
+Install Python and `pdm` with cache and extract metadata
+
+## Usage
+
+```yaml
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/pdm/init@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `python-version` | Python version to use | `3.11` | `true` |
+| `group` | Dependency group to install | `""` | `false` |
+| `history` | Fetch the full history | `false` | `false` |
+| `pypi-token` | Private PyPI token (read) | `""` | `false` |
+| `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
+
+
+## Outputs
+
+N/A
+

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -1,0 +1,51 @@
+name: Initialize `pdm`
+description: Install Python and `pdm` with cache and extract metadata
+
+inputs:
+  python-version:
+    description: Python version to use
+    required: true
+    default: "3.11"
+  group:
+    description: Dependency group to install
+  history:
+    description: Fetch the full history
+    required: false
+    default: false
+  pypi-token:
+    description: Private PyPI token (read)
+    required: false
+    default: ""
+  github-token:
+    description: A Github token with proper permissions
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Clone
+      uses: actions/checkout@v4
+      with:
+        token: ${{ inputs.github-token }}
+        fetch-depth: ${{ inputs.history == 'true' && '0' || '1' }}
+
+    - name: Setup git
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@ledger.fr
+      shell: bash
+
+    - name: Set up Python and PDM
+      uses: pdm-project/setup-pdm@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: true
+
+    - name: Install dependencies
+      run: |
+        echo "${{ github.workspace }}/.venv/bin/python" > .pdm-python
+        pdm sync --dev --group ${{ inputs.group }}
+      env:
+        PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token }}
+      shell: bash

--- a/pdm/lint/README.md
+++ b/pdm/lint/README.md
@@ -1,0 +1,25 @@
+# Lint
+
+Lint running pre-commit hooks
+
+## Usage
+
+```yaml
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/pdm/lint@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `python-version` | Python version used to build | `3.11` | `false` |
+
+
+## Outputs
+
+N/A
+

--- a/pdm/lint/action.yml
+++ b/pdm/lint/action.yml
@@ -1,0 +1,18 @@
+name: Lint
+description: Lint running pre-commit hooks
+
+inputs:
+  python-version:
+    description: Python version used to build
+    required: false
+    default: "3.11"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Lint with pre-commit
+      uses: pre-commit/action@v3.0.0

--- a/pdm/meta/README.md
+++ b/pdm/meta/README.md
@@ -1,0 +1,31 @@
+# Extract `pdm` metadata
+
+Extract required metadata from `pdm`
+
+## Usage
+
+```yaml
+jobs:
+  meta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/pdm/meta@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `python-version` | Python version used by `pdm` | `3.11` | `false` |
+
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `has_tests` | Wether the project has tests exposed through the `test` command |
+| `has_coverage` | Wether the project has tests with coverage exposed through the `cover` command |
+| `has_docs` | Wether the project has a documentation exposed through the `doc` command |
+| `has_openapi` | Wether the project has an OpenAPI specification exposed through the `doc:openapi` command |
+
+

--- a/pdm/meta/action.yml
+++ b/pdm/meta/action.yml
@@ -1,0 +1,95 @@
+
+name: Extract `pdm` metadata
+description: Extract required metadata from `pdm`
+
+inputs:
+  python-version:
+    description: Python version used by `pdm`
+    required: false
+    default: "3.11"
+    
+
+outputs:
+  has_tests:
+    description: Wether the project has tests exposed through the `test` command
+    value: ${{ steps.commands.outputs.tests }}
+  has_coverage:
+    description: Wether the project has tests with coverage exposed through the `cover` command
+    value: ${{ steps.commands.outputs.tests }}
+  has_docs:
+    description: Wether the project has a documentation exposed through the `doc` command
+    value: ${{ steps.commands.outputs.docs }}
+  has_openapi:
+    description: Wether the project has an OpenAPI specification exposed through the `doc:openapi` command
+    value: ${{ steps.commands.outputs.openapi  }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python and PDM
+      uses: pdm-project/setup-pdm@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: true
+
+    - name: Extract existing commands
+      id: commands
+      run: | 
+        COMMANDS=$(pdm run --json)
+
+        HAS_TESTS=$(jq 'has("test")' <<< "$COMMANDS")
+        echo "has_tests=${HAS_TESTS}" >> $GITHUB_OUTPUT
+
+        HAS_COVERAGE=$(jq 'has("cover")' <<< "$COMMANDS")
+        echo "has_coverage=${HAS_COVERAGE}" >> $GITHUB_OUTPUT
+
+        HAS_DOCS=$(jq 'has("doc")' <<< "$COMMANDS")
+        echo "has_docs=${HAS_DOCS}" >> $GITHUB_OUTPUT
+
+        HAS_OPENAPI=$(jq 'has("doc:openapi")' <<< "$COMMANDS")
+        echo "has_openapi=${HAS_OPENAPI}" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Display commands output
+      run: echo "${{ toJson(steps.commands.outputs) }}"
+      shell: bash
+
+    - name: Compute base ref (branch/tag) name
+      id: refs
+      run: |
+        if  [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
+          echo "target=origin/${GITHUB_BASE_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        elif  [[ $GITHUB_REF == refs/heads/feature/* ]]; then
+          echo "target=main" >> $GITHUB_OUTPUT
+        else
+          echo "target=HEAD^" >> $GITHUB_OUTPUT
+        fi
+
+        branch=${{ github.event.pull_request && github.head_ref || github.ref_name }}
+        sha=${{ github.sha }}
+        if  [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
+          echo "branch should be ${GITHUB_HEAD_REF#refs/heads/}"
+          echo "sha should be ${{ github.event.pull_request.head.sha }}"
+        elif [[ $GITHUB_REF == refs/heads/* ]]; then
+          echo "branch should be ${GITHUB_REF#refs/heads/}"
+          echo "sha should be ${{ github.sha }}"
+        fi
+
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          # It's a tag aka. a semver dotted release (X.Y.Z assuming no v prefix)
+          version=${GITHUB_REF#refs/tags/}
+          echo "branch=${version}" >> $GITHUB_OUTPUT
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+        elif [[ ! -z "$branch" ]]; then
+          echo "branch=${branch}" >> $GITHUB_OUTPUT
+          echo "version=${branch//\//-}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "sha=${sha}" >> $GITHUB_OUTPUT
+        else
+          echo "::error ::Unkown case: current build is neither a tag, a branch or a pull request"
+          exit 1
+        fi
+      shell: bash
+    - name: Display refs output
+      run: echo "${{ toJson(steps.refs.outputs) }}"
+      shell: bash

--- a/pdm/release/README.md
+++ b/pdm/release/README.md
@@ -1,0 +1,33 @@
+# Release
+
+Bump version and publish release assets
+
+## Usage
+
+```yaml
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/pdm/release@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `kind` | Kind of project to release (lib/app) | `app` | `true` |
+| `pypi-token` | A Token to Ledger private PyPI | `""` | `true` |
+| `github-token` | A Github token with | `""` | `true` |
+| `increment` | Kind of increment (optional: MAJOR|MINOR|PATCH) | `""` | `false` |
+
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `url` | The generated Github Release URL |
+| `version` | The released version |
+| `documentation` | The released documentation URL |
+
+

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -1,0 +1,143 @@
+name: Release
+description: Bump version and publish release assets
+
+inputs:
+  kind:
+    description: Kind of project to release (lib/app)
+    required: true
+    default: app
+  pypi-token:
+    description: A Token to Ledger private PyPI
+    required: true
+    default: ""
+  github-token:
+    description: A Github token with 
+    required: true
+  increment:
+    description: "Kind of increment (optional: MAJOR|MINOR|PATCH)"
+    default: ''
+    required: false
+
+
+outputs:
+  url: 
+    description: The generated Github Release URL
+    value: ${{ steps.release.outputs.url }}
+  version: 
+    description: The released version
+    value: ${{ steps.bump.outputs.version }}
+  documentation: 
+    description: The released documentation URL
+    value: ${{ steps.doc.outputs.url }}
+
+
+runs:
+  using: composite
+  steps:
+    - name: Clone and install dependencies
+      uses: LedgerHQ/actions/pdm/init@main
+      with:
+        group: docs
+        history: true
+        github-token: ${{ inputs.github-token }}
+        pypi-token: ${{ inputs.pypi-token }}
+        python-version: "3.11"
+
+    - name: Bump using commitizen
+      id: bump
+      run: |
+        CMD=('pdm' 'bump' '--changelog-to-stdout')
+        if [[ $INPUT_INCREMENT ]]; then
+          CMD+=('--increment' "$INPUT_INCREMENT")
+        fi
+        "${CMD[@]}" > body.md
+
+        REV="$(pdm run cz version --project)"
+        echo "REVISION=${REV}" >>"$GITHUB_ENV"
+        echo "version=${REV}" >>"$GITHUB_OUTPUT"
+      env:
+        FORCE_COLOR: true
+      shell: bash
+
+    # Build once to publish the same package on every repository
+    - name: Build distribution
+      if: inputs.kind == 'lib'
+      run: pdm build
+      env:
+        FORCE_COLOR: true
+      shell: bash
+
+    - name: Push to GemFury
+      if: inputs.kind == 'lib' && env.PDM_PUBLISH_USERNAME != null
+      env:
+        PDM_PUBLISH_REPO: https://push.fury.io/ledger
+        PDM_PUBLISH_USERNAME: ${{ inputs.pypi-token }}
+        PDM_PUBLISH_PASSWORD: "-" # tricks github actions YAML parser and PDM test for empty password
+        FORCE_COLOR: true
+      run: pdm publish --no-build
+      shell: bash
+
+    - name: Push to our internal Nexus
+      if: inputs.kind == 'lib' && env.NEXUS_HOST != null && env.NEXUS_USER != null && env.NEXUS_PASSWORD != null
+      env:
+        PDM_PUBLISH_REPO: https://${{ env.NEXUS_HOST }}/repository/pypi-internal/
+        PDM_PUBLISH_USERNAME: ${{ env.NEXUS_USER }}
+        PDM_PUBLISH_PASSWORD: ${{ env.NEXUS_PASSWORD }}
+        FORCE_COLOR: true
+      run: pdm publish --no-build
+      shell: bash
+
+    - name: Docker image
+      uses: LedgerHQ/actions/pdm/docker@main
+      id: docker
+      if: inputs.kind == 'app'
+      with:
+        clone: false
+        version: ${{ env.REVISION }}
+        pypi-token: ${{ inputs.pypi-token }}
+        github-token: ${{ inputs.github-token }}
+
+    - name: Add docker image to release body
+      if: steps.docker.outputs.image
+      run: |
+        echo -e "\n**Docker image**: \`${{ steps.docker.outputs.image }}@${{ steps.docker.outputs.digest }}\`\n" >> body.md
+      shell: bash
+
+    - name: Documentation
+      id: doc
+      uses: LedgerHQ/actions/pdm/doc@main
+      with:
+        version: ${{ env.REVISION }}
+        pypi-token: ${{ inputs.pypi-token }}
+        openapi: ${{ inputs.kind == 'app' }}
+        site: true
+        init: false
+
+    - name: Add doc to release body
+      if: steps.doc.outputs.url
+      run: |
+        echo -e "\n**Documentation**: <${{ steps.doc.outputs.url }}>\n" >> body.md
+      shell: bash
+
+    - name: Push release commit and tag
+      run: |
+        git push -f
+        git push -f origin ${{ env.REVISION }}
+      shell: bash
+
+    - name: Github Release
+      id: release
+      uses: softprops/action-gh-release@v1
+      with:
+        body_path: "body.md"
+        tag_name: ${{ env.REVISION }}
+        token: ${{ inputs.github-token }}
+        fail_on_unmatched_files: false
+        files: |
+          dist/*
+          docs/openapi.yaml
+          CHANGELOG.md
+  
+    - name: Publish summary
+      run: echo "🚀 [Version ${{ env.REVISION }}](${{ steps.release.outputs.url }}) has been published" >> $GITHUB_STEP_SUMMARY
+      shell: bash

--- a/pdm/test/README.md
+++ b/pdm/test/README.md
@@ -1,0 +1,28 @@
+# Test
+
+Execute test using `pdm` scripts
+
+## Usage
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/pdm/test@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `python-version` | Python version to run the tests with | `3.11` | `true` |
+| `pypi-token` | A Token to Ledger private PyPI with read permissions | `""` | `true` |
+| `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
+| `init` | Clone & sync | `true` | `false` |
+
+
+## Outputs
+
+N/A
+

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -1,0 +1,49 @@
+name: Test
+description: Execute test using `pdm` scripts
+
+inputs:
+  python-version:
+    description: Python version to run the tests with
+    required: true
+    default: "3.11"
+  pypi-token:
+    description: A Token to Ledger private PyPI with read permissions
+    required: true
+    default: ""
+  github-token:
+    description: A Github token with proper permissions
+    default: ${{ github.token }}
+  init:
+    description: Clone & sync
+    default: true
+
+runs:
+  using: composite
+  steps:
+    - name: Clone and install dependencies
+      if: inputs.init == 'true'
+      uses: LedgerHQ/actions/pdm/init@main
+      with:
+        python-version: ${{ inputs.python-version }}
+        group: test
+        pypi-token: ${{ inputs.pypi-token }}
+
+    - name: Run Tests
+      run: pdm cover -v --force-sugar --color=yes
+      env:
+        FORCE_COLOR: true
+      shell: bash
+
+    - name: Pytest coverage comment
+      id: coverage
+      uses: MishaKav/pytest-coverage-comment@v1.1.50
+      with:
+        github-token: ${{ inputs.github-token }}
+        pytest-xml-coverage-path: ./reports/coverage.xml
+        junitxml-path: ./reports/tests.xml
+        title: Coverage Report for Python ${{ inputs.python-version }}
+        unique-id-for-comment: ${{ inputs.python-version }}
+
+    - name: Add coverage report to summary
+      run: echo -e ${{ steps.coverage.outputs.summaryReport }} >> $GITHUB_STEP_SUMMARY
+      shell: bash

--- a/slack/README.md
+++ b/slack/README.md
@@ -1,0 +1,10 @@
+# Slack-related actions
+
+Provides some reusable Slack actions.
+
+## Actions
+
+| Name | Description |
+|--------|-------------|
+| [Slack Notify Release (`release`)](release/) | Dispatch a Slack release Notification in a given channel |
+

--- a/slack/release/README.md
+++ b/slack/release/README.md
@@ -1,0 +1,31 @@
+# Slack Notify Release
+
+Dispatch a Slack release Notification in a given channel
+
+## Usage
+
+```yaml
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/slack/release@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `project` | Project name | `""` | `true` |
+| `version` | Released version | `""` | `true` |
+| `webhook-url` | Slack webhook URL | `""` | `true` |
+| `channel` | Channel to notify in | `#vault-ci-notifications` | `false` |
+| `github-release` | An optional github release URL | `""` | `false` |
+| `docker` | An optionnal Docker image URL | `""` | `false` |
+| `documentation` | An optional documentation URL | `""` | `false` |
+
+
+## Outputs
+
+N/A
+

--- a/slack/release/action.yml
+++ b/slack/release/action.yml
@@ -1,0 +1,135 @@
+name: Slack Notify Release
+description: Dispatch a Slack release Notification in a given channel
+
+inputs:
+  project:
+    description: Project name
+    required: true
+  version:
+    description: Released version
+    required: true
+  webhook-url:
+    description: Slack webhook URL
+    required: true
+  channel:
+    description: Channel to notify in
+    default: "#vault-ci-notifications"
+  github-release:
+    description: An optional github release URL
+  docker:
+    description: An optionnal Docker image URL
+  documentation:
+    description: An optional documentation URL
+
+runs:
+  using: composite
+  steps:
+    - name: Build Slacks blocks
+      id: blocks
+      run: | 
+        PROJECT="${{ inputs.project }}"
+        VERSION="${{ inputs.version }}"
+        REPOSITORY="${{ github.repository }}"
+        SLUG="${{ github.event.repository.name }}"
+        VERSION="${{ inputs.version }}"
+        DOCKER="${{ inputs.docker }}"
+        DOC="${{ inputs.documentation }}"
+        GH_RELEASE="${{ inputs.github-release }}"
+
+        JSON=$(jq -n \
+          --arg project "$PROJECT" \
+          --arg version "$VERSION" \
+        '{
+          "blocks": [
+            {
+              "type": "header",
+              "text": {
+              "type": "plain_text",
+              "text": ":rocket_vault: \($project) \($version) :rocket_vault:",
+              "emoji": true
+              }
+            },
+            {
+              "type": "section",
+              "text": {
+              "type": "mrkdwn",
+              "text": "\($project) has been released in version \($version) :point_down:"
+              }
+            }
+          ]
+        }')
+
+        if [[ "$DOCKER" ]]; then
+          DOCKER_SEGMENT=$(jq -n --arg docker ${DOCKER} '{
+          "type": "context",
+          "elements": [
+            {
+              "type": "mrkdwn",
+              "text": ":docker: *Docker image*"
+            },
+            {
+              "type": "mrkdwn",
+              "text": "`\($docker)`"
+            }
+          ]
+          }')
+          JSON=$(echo $JSON | jq --argjson docker "$DOCKER_SEGMENT" '.blocks += [$docker]')
+        fi
+
+        ACTIONS=$(jq -n '{
+          "type": "actions",
+          "elements": []
+        }')
+
+        if [[ "${GH_RELEASE}" ]]; then
+          RELEASE_BTN=$(jq -n --arg url ${GH_RELEASE} '{
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": ":github: Github release",
+              "emoji": true
+            },
+            "url": $url
+          }')
+          ACTIONS=$(echo $ACTIONS | jq --argjson action "$RELEASE_BTN" '.elements += [$action]')
+        fi
+
+        if [[ "${DOCKER}" ]]; then
+          URL="https://github.com/${REPOSITORY}/pkgs/container/${SLUG}/${VERSION}"
+          DOCKER_BTN=$(jq -n --arg url ${URL} '{
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": ":docker: Docker image",
+              "emoji": true
+            },
+            "url": $url
+          }')
+          ACTIONS=$(echo $ACTIONS | jq --argjson action "$DOCKER_BTN" '.elements += [$action]')
+        fi
+
+        if [[ "${DOC}" ]]; then
+          DOC_BTN=$(jq -n --arg url ${DOC} '{
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": ":documentation: Documentation",
+              "emoji": true
+            },
+            "url": $url
+          }')
+          ACTIONS=$(echo $ACTIONS | jq --argjson action "$DOC_BTN" '.elements += [$action]')
+        fi
+
+        JSON=$(echo $JSON | jq --argjson actions "$ACTIONS" '.blocks += [$actions]')
+        echo "json=$JSON" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Send Slack notification
+      uses: Ilshidur/action-slack@2.1.0
+      if: env.SLACK_WEBHOOK != null
+      env:
+          SLACK_WEBHOOK: ${{ inputs.webhook-url }}
+          SLACK_CHANNEL: ${{ inputs.channel }}
+          SLACK_AVATAR: https://emoji.slack-edge.com/T032Z0S1J/rocket_vault/db3b32d9d9f82429.png
+          SLACK_CUSTOM_PAYLOAD: ${{ steps.blocks.output.json }}


### PR DESCRIPTION
Provides `pdm` actions for the entire lifecycle of a `pdm`-based project, lib or service.

## Sample runs

- CI for lib: https://github.com/LedgerHQ/les-copier-demo/actions/runs/7818583568
- CI for service: https://github.com/LedgerHQ/les-copier-demo/actions/runs/7816532564
- CI for service without `goss`: https://github.com/LedgerHQ/les-copier-demo/actions/runs/7802772748
- Release for lib: https://github.com/LedgerHQ/les-copier-demo/actions/runs/7818647647
  - Generated GitHub release: https://github.com/LedgerHQ/les-copier-demo/releases/tag/0.3.0
  - Generated doc: https://ledgerhq.github.io/les-copier-demo/0.2.0
- Release for service: https://github.com/LedgerHQ/les-copier-demo/actions/runs/7817736451
  - Generated GitHub release: https://github.com/LedgerHQ/les-copier-demo/releases/tag/0.2.0
  - Generated doc: https://ledgerhq.github.io/les-copier-demo/0.2.0

VG-14148