### PR TITLE
fix(pdm/release): fix Markdown table format in README

### DIFF
--- a/pdm/release/README.md
+++ b/pdm/release/README.md
@@ -19,7 +19,7 @@ jobs:
 | `kind` | Kind of project to release (lib/app) | `app` | `true` |
 | `pypi-token` | A Token to Ledger private PyPI | `""` | `true` |
 | `github-token` | A Github token with | `""` | `true` |
-| `increment` | Kind of increment (optional: MAJOR|MINOR|PATCH) | `""` | `false` |
+| `increment` | Kind of increment (optional: `MAJOR\|MINOR\|PATCH`) | `""` | `false` |
 
 
 ## Outputs


### PR DESCRIPTION
Using `|` in the description of `increment` adds columns to the table, in an unexpected way.

Escape `|` to fix the format of the Markdown table.