### PR TITLE
fix(deps): bump pre-commit/action from 3.0.0 to 3.0.1

### DIFF
--- a/pdm/lint/action.yml
+++ b/pdm/lint/action.yml
@@ -15,4 +15,4 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
     - name: Lint with pre-commit
-      uses: pre-commit/action@v3.0.0
+      uses: pre-commit/action@v3.0.1

--- a/python-app/lint/action.yml
+++ b/python-app/lint/action.yml
@@ -4,4 +4,4 @@ description: "run pre-commit hooks"
 runs:
   using: "composite"
   steps:
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/python-lib/test/action.yml
+++ b/python-lib/test/action.yml
@@ -19,7 +19,7 @@ runs:
         echo "PACKAGE_NAME=$(python -c 'import setuptools;print(setuptools.find_packages(exclude=["tests", "tests.*"])[0])')" >> $GITHUB_ENV
       shell: bash
     - name: Lint
-      uses: pre-commit/action@v3.0.0
+      uses: pre-commit/action@v3.0.1
     - name: Install dependencies
       run: |
         export PIP_EXTRA_INDEX_URL


### PR DESCRIPTION
GitHub Actions workflows are complaning:

> Node.js 16 actions are deprecated. Please update the following actions
> to use Node.js 20: actions/cache@v3. For more information see:
> https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

This was fixed in https://github.com/pre-commit/action/releases/tag/v3.0.1