### PR TITLE
fix(slack/release): use Github Actions heredoc syntax for multiline output (fix #131)

### DIFF
--- a/slack/release/action.yml
+++ b/slack/release/action.yml
@@ -44,16 +44,16 @@ runs:
             {
               "type": "header",
               "text": {
-              "type": "plain_text",
-              "text": ":rocket_vault: \($project) \($version) :rocket_vault:",
-              "emoji": true
+                "type": "plain_text",
+                "text": ":rocket_vault: \($project) \($version) :rocket_vault:",
+                "emoji": true
               }
             },
             {
               "type": "section",
               "text": {
-              "type": "mrkdwn",
-              "text": "\($project) has been released in version \($version) :point_down:"
+                "type": "mrkdwn",
+                "text": "\($project) has been released in version \($version) :point_down:"
               }
             }
           ]
@@ -122,7 +122,12 @@ runs:
         fi
 
         JSON=$(echo $JSON | jq --argjson actions "$ACTIONS" '.blocks += [$actions]')
-        echo "json=$JSON" >> $GITHUB_OUTPUT
+
+        # Only way to return multiline output
+        echo "json<<JSON" >> $GITHUB_OUTPUT
+        echo "$JSON" >> $GITHUB_OUTPUT
+        echo "JSON" >> $GITHUB_OUTPUT
+
       shell: bash
 
     - name: Send Slack notification


### PR DESCRIPTION
This PR ensure the the multiline JSON payload is properly stored as step outputs using GHA dedicated syntax for multiline outputs (cf. https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings)

Fixes #131 