### PR TITLE
feat(pdm): support some extra parameters to the `pdm cover` command

### DIFF
--- a/pdm/test/README.md
+++ b/pdm/test/README.md
@@ -20,6 +20,7 @@ jobs:
 | `pypi-token` | A Token to Ledger private PyPI with read permissions | `""` | `true` |
 | `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
 | `init` | Clone & sync | `true` | `false` |
+| `parameters` | Some extra paramaters to the `pdm cover` command | `""` | `false` |
 
 
 ## Outputs

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -16,6 +16,9 @@ inputs:
   init:
     description: Clone & sync
     default: true
+  parameters:
+    description: Some extra parameters to pass to `pdm cover`
+    default: ""
 
 runs:
   using: composite
@@ -29,7 +32,7 @@ runs:
         pypi-token: ${{ inputs.pypi-token }}
 
     - name: Run Tests
-      run: pdm cover -v --force-sugar --color=yes
+      run: pdm cover -v --force-sugar --color=yes ${{ inputs.parameters }}
       env:
         FORCE_COLOR: true
       shell: bash


### PR DESCRIPTION
Allows to specify extra `parameters` to the `pdm cover` in the `pdm/test` action.