### PR TITLE
feat(pdm): allows group exclusion on init/install

### DIFF
--- a/pdm/doc/build/README.md
+++ b/pdm/doc/build/README.md
@@ -21,6 +21,8 @@ jobs:
 | `openapi` | Whether or not to build OpenAPI specs | `false` | `false` |
 | `site` | Whether or not to build a documentation site | `false` | `false` |
 | `init` | Clone & sync | `true` | `false` |
+| `group` | Dependency group(s) to install | `docs` | `false` |
+| `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
 
 
 ## Outputs

--- a/pdm/doc/build/action.yml
+++ b/pdm/doc/build/action.yml
@@ -18,6 +18,12 @@ inputs:
   init:
     description: Clone & sync
     default: true
+  group:
+    description: Dependency group(s) to install
+    default: docs
+  exclude-group:
+    description: Dependency group(s) to exclude from install
+    default: ''
 
 runs:
   using: composite
@@ -26,7 +32,8 @@ runs:
       uses: LedgerHQ/actions/pdm/init@main
       if: inputs.init == 'true'
       with:
-        group: docs
+        group: ${{ inputs.group }}
+        exclude-group: ${{ inputs.exclude-group }}
         history: true
         pypi-token: ${{ inputs.pypi-token }}
         python-version: ${{ inputs.python-version }}
@@ -64,7 +71,7 @@ runs:
       env:
         FORCE_COLOR: true
       shell: bash
-      
+
     - name: Upload the generated documentation
       if: inputs.site == 'true'
       uses: actions/upload-artifact@v4

--- a/pdm/doc/publish/README.md
+++ b/pdm/doc/publish/README.md
@@ -21,6 +21,8 @@ jobs:
 | `site` | Publish a documentation site | `false` | `false` |
 | `pypi-token` | A read token for private PyPI access | `""` | `false` |
 | `init` | Clone & sync | `true` | `false` |
+| `group` | Dependency group(s) to install | `docs` | `false` |
+| `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
 
 
 ## Outputs

--- a/pdm/doc/publish/action.yml
+++ b/pdm/doc/publish/action.yml
@@ -17,6 +17,12 @@ inputs:
   init:
     description: Clone & sync
     default: true
+  group:
+    description: Dependency group(s) to install
+    default: docs
+  exclude-group:
+    description: Dependency group(s) to exclude from install
+    default: ''
 
 outputs:
   url:
@@ -30,14 +36,15 @@ runs:
       if: inputs.init == 'true'
       uses: LedgerHQ/actions/pdm/init@main
       with:
-        group: docs
+        group: ${{ inputs.group }}
+        exclude-group: ${{ inputs.exclude-group }}
         history: true
         pypi-token: ${{ inputs.pypi-token }}
 
     - uses: actions/download-artifact@v4
       with:
         name: changelog
-    
+
     - uses: actions/download-artifact@v4
       if: inputs.openapi == 'true'
       with:

--- a/pdm/docker/README.md
+++ b/pdm/docker/README.md
@@ -16,9 +16,10 @@ jobs:
 
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
+| `clone` | Wether to clone or not | `true` | `false` |
 | `version` | Force the built version | `""` | `false` |
 | `pypi-token` | A Token to Ledger private PyPI with read permissions | `""` | `true` |
-| `github-token` | A Github token with | `""` | `false` |
+| `github-token` | A Github token with proper permissions | `""` | `false` |
 
 
 ## Outputs

--- a/pdm/init/README.md
+++ b/pdm/init/README.md
@@ -17,7 +17,8 @@ jobs:
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
 | `python-version` | Python version to use | `3.11` | `true` |
-| `group` | Dependency group to install | `""` | `false` |
+| `group` | Dependency group(s) to install | `""` | `false` |
+| `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
 | `history` | Fetch the full history | `false` | `false` |
 | `pypi-token` | Private PyPI token (read) | `""` | `false` |
 | `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -7,7 +7,11 @@ inputs:
     required: true
     default: "3.11"
   group:
-    description: Dependency group to install
+    description: Dependency group(s) to install
+    default: ''
+  exclude-group:
+    description: Dependency group(s) to exclude from install
+    default: ''
   history:
     description: Fetch the full history
     required: false
@@ -50,7 +54,12 @@ runs:
     - name: Install dependencies (main, all extras and specified dev group)
       run: |
         echo "${{ github.workspace }}/.venv/bin/python" > .pdm-python
-        pdm sync --group :all --dev --group ${{ inputs.group }}
+        params="--group :all --dev"
+        [ -z "${GROUPS}" ] && params+=" --group ${GROUPS}"
+        [ -z "${EXCLUDED_GROUPS}" ] && params+=" --without ${EXCLUDED_GROUPS}"
+        pdm sync "${params}"
       env:
         PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token }}
+        GROUPS: ${{ inputs.group }}
+        EXCLUDED_GROUPS: ${{ inputs.exclude-group }}
       shell: bash

--- a/pdm/release/README.md
+++ b/pdm/release/README.md
@@ -20,6 +20,8 @@ jobs:
 | `pypi-token` | A Token to Ledger private PyPI | `""` | `true` |
 | `github-token` | A Github token with | `""` | `true` |
 | `increment` | Kind of increment (optional: `MAJOR\|MINOR\|PATCH`) | `""` | `false` |
+| `group` | Dependency group(s) to install | `docs` | `false` |
+| `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
 
 
 ## Outputs

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -15,8 +15,13 @@ inputs:
     required: true
   increment:
     description: "Kind of increment (optional: MAJOR|MINOR|PATCH)"
-    default: ''
     required: false
+  group:
+    description: Dependency group(s) to install
+    default: docs
+  exclude-group:
+    description: Dependency group(s) to exclude from install
+    default: ''
 
 
 outputs:
@@ -37,7 +42,8 @@ runs:
     - name: Clone and install dependencies
       uses: LedgerHQ/actions/pdm/init@main
       with:
-        group: docs
+        group: ${{ inputs.group }}
+        exclude-group: ${{ inputs.exclude-group }}
         history: true
         github-token: ${{ inputs.github-token }}
         pypi-token: ${{ inputs.pypi-token }}

--- a/pdm/test/README.md
+++ b/pdm/test/README.md
@@ -20,7 +20,9 @@ jobs:
 | `pypi-token` | A Token to Ledger private PyPI with read permissions | `""` | `true` |
 | `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
 | `init` | Clone & sync | `true` | `false` |
-| `parameters` | Some extra paramaters to the `pdm cover` command | `""` | `false` |
+| `parameters` | Some extra parameters to pass to `pdm cover` | `""` | `false` |
+| `group` | Dependency group(s) to install | `test` | `false` |
+| `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
 
 
 ## Outputs

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -19,6 +19,12 @@ inputs:
   parameters:
     description: Some extra parameters to pass to `pdm cover`
     default: ""
+  group:
+    description: Dependency group(s) to install
+    default: test
+  exclude-group:
+    description: Dependency group(s) to exclude from install
+    default: ''
 
 runs:
   using: composite
@@ -28,7 +34,8 @@ runs:
       uses: LedgerHQ/actions/pdm/init@main
       with:
         python-version: ${{ inputs.python-version }}
-        group: test
+        group: ${{ inputs.group }}
+        exclude-group: ${{ inputs.exclude-group }}
         pypi-token: ${{ inputs.pypi-token }}
 
     - name: Run Tests


### PR DESCRIPTION
This PR:
- allows specifying some group exclusions on the `pdm/init` action
- allows customizing the group installed for each action
- ensure that specified groups are given to nested actions

This is especially useful for projects having some heavy optional (not dev) dependencies we don't want to install for each job.

It relies on PDM 2.13 `--without` parameter (https://github.com/pdm-project/pdm/issues/2258) which is automatically installed by those actions