### PR TITLE
refactor(pdm): merge `pdm/meta` into `pdm/init` and fixes outputs (fix #144)

### DIFF
--- a/pdm/init/README.md
+++ b/pdm/init/README.md
@@ -26,5 +26,12 @@ jobs:
 
 ## Outputs
 
-N/A
+| Output | Description |
+|--------|-------------|
+| `has_tests` | Wether the project has tests exposed through the `test` command |
+| `has_coverage` | Wether the project has tests with coverage exposed through the `cover` command |
+| `has_docs` | Wether the project has a documentation exposed through the `doc` command |
+| `has_openapi` | Wether the project has an OpenAPI specification exposed through the `doc:openapi` command |
+| `has_docker` | Wether the project a Docker image (aka. a `Dockerfile` present at root) |
+
 

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -25,6 +25,24 @@ inputs:
     required: false
     default: ${{ github.token }}
 
+outputs:
+  has_tests:
+    description: Wether the project has tests exposed through the `test` command
+    value: ${{ steps.meta.outputs.has_tests }}
+  has_coverage:
+    description: Wether the project has tests with coverage exposed through the `cover` command
+    value: ${{ steps.meta.outputs.has_coverage }}
+  has_docs:
+    description: Wether the project has a documentation exposed through the `doc` command
+    value: ${{ steps.meta.outputs.has_docs }}
+  has_openapi:
+    description: Wether the project has an OpenAPI specification exposed through the `doc:openapi` command
+    value: ${{ steps.meta.outputs.has_openapi }}
+  has_docker:
+    description: Wether the project a Docker image (aka. a `Dockerfile` present at root)
+    value: ${{ steps.meta.outputs.has_docker }}
+
+
 runs:
   using: composite
   steps:
@@ -62,4 +80,28 @@ runs:
         PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token }}
         GROUPS: ${{ inputs.group }}
         EXCLUDED_GROUPS: ${{ inputs.exclude-group }}
+      shell: bash
+
+    - name: Extract some metadata
+      id: meta
+      run: |
+        COMMANDS=$(pdm run --json)
+
+        HAS_TESTS=$(jq 'has("test")' <<< "$COMMANDS")
+        echo "has_tests=${HAS_TESTS}" >> $GITHUB_OUTPUT
+
+        HAS_COVERAGE=$(jq 'has("cover")' <<< "$COMMANDS")
+        echo "has_coverage=${HAS_COVERAGE}" >> $GITHUB_OUTPUT
+
+        HAS_DOCS=$(jq 'has("doc")' <<< "$COMMANDS")
+        echo "has_docs=${HAS_DOCS}" >> $GITHUB_OUTPUT
+
+        HAS_OPENAPI=$(jq 'has("doc:openapi")' <<< "$COMMANDS")
+        echo "has_openapi=${HAS_OPENAPI}" >> $GITHUB_OUTPUT
+
+        [ -f Dockerfile ] && HAS_DOCKER='true' || HAS_DOCKER='false'
+        echo "has_docker=${HAS_DOCKER}" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Display commands output
+      run: echo "${{ toJson(steps.meta.outputs) }}"
       shell: bash

--- a/pdm/meta/README.md
+++ b/pdm/meta/README.md
@@ -2,6 +2,8 @@
 
 Extract required metadata from `pdm`
 
+**Deprecatation notice**: this actions is deprecated and has been merged into `pdm/init`.
+
 ## Usage
 
 ```yaml
@@ -27,5 +29,9 @@ jobs:
 | `has_coverage` | Wether the project has tests with coverage exposed through the `cover` command |
 | `has_docs` | Wether the project has a documentation exposed through the `doc` command |
 | `has_openapi` | Wether the project has an OpenAPI specification exposed through the `doc:openapi` command |
+| `target` | The target branch in case of pull-request |
+| `version` | The deterministic version (aka. Docker usable version based on the current branch) |
+| `branch` | The real actual branch (resolved in case of pull-request) |
+| `sha` | The current commit `sha1` being tested/builded |
 
 

--- a/pdm/meta/action.yml
+++ b/pdm/meta/action.yml
@@ -7,21 +7,34 @@ inputs:
     description: Python version used by `pdm`
     required: false
     default: "3.11"
-    
+
 
 outputs:
   has_tests:
     description: Wether the project has tests exposed through the `test` command
-    value: ${{ steps.commands.outputs.tests }}
+    value: ${{ steps.commands.outputs.has_tests }}
   has_coverage:
     description: Wether the project has tests with coverage exposed through the `cover` command
-    value: ${{ steps.commands.outputs.tests }}
+    value: ${{ steps.commands.outputs.has_coverage }}
   has_docs:
     description: Wether the project has a documentation exposed through the `doc` command
-    value: ${{ steps.commands.outputs.docs }}
+    value: ${{ steps.commands.outputs.has_docs }}
   has_openapi:
     description: Wether the project has an OpenAPI specification exposed through the `doc:openapi` command
-    value: ${{ steps.commands.outputs.openapi  }}
+    value: ${{ steps.commands.outputs.has_openapi }}
+  target:
+    description: The target branch in case of pull-request
+    value: ${{ steps.refs.outputs.target }}
+  version:
+    description: The deterministic version (aka. Docker usable version based on the current branch)
+    value: ${{ steps.refs.outputs.version }}
+  branch:
+    description: The real actual branch (resolved in case of pull-request)
+    value: ${{ steps.refs.outputs.branch }}
+  sha:
+    description: The current commit `sha1` being tested/builded
+    value: ${{ steps.refs.outputs.sha }}
+
 
 runs:
   using: "composite"
@@ -35,7 +48,7 @@ runs:
 
     - name: Extract existing commands
       id: commands
-      run: | 
+      run: |
         COMMANDS=$(pdm run --json)
 
         HAS_TESTS=$(jq 'has("test")' <<< "$COMMANDS")

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -41,6 +41,7 @@ runs:
   steps:
     - name: Clone and install dependencies
       uses: LedgerHQ/actions/pdm/init@main
+      id: meta
       with:
         group: ${{ inputs.group }}
         exclude-group: ${{ inputs.exclude-group }}
@@ -97,7 +98,7 @@ runs:
     - name: Docker image
       uses: LedgerHQ/actions/pdm/docker@main
       id: docker
-      if: inputs.kind == 'app'
+      if: inputs.kind == 'app' and steps.meta.outputs.has_docker
       with:
         clone: false
         version: ${{ env.REVISION }}
@@ -116,7 +117,7 @@ runs:
       with:
         version: ${{ env.REVISION }}
         pypi-token: ${{ inputs.pypi-token }}
-        openapi: ${{ inputs.kind == 'app' }}
+        openapi: ${{ inputs.kind == 'app' && steps.meta.outputs.has_openapi }}
         site: true
         init: false
 


### PR DESCRIPTION
This PR merges `pdm/meta` into `pdm/init` and deprecate `pdm/meta` (but fix it until everybody use `pdm/init` outputs). It should fix #144 

Remarks (that might need to be fixed before merging this PR):
- only `has_*` predicate have been integrated into `pdm/init` because:
  - not sure the `sha` is still required (already provided by `github.sha` and no computation on it)
  - `target` and `branches` were initially made for the Gate CI which was using `pull_request_target` but this is not the case anymore (tldr. I think we ~can~ should remove this)
  - `version` seems to be computed twice (cf. https://github.com/LedgerHQ/actions/blob/main/pdm/docker/action.yml#L51-L60) with different algo
- `pdm/meta` is kept but deprecated to avoid breaking existing workflows using it. Will be removed as soon as those workflows removed the `pdm/meta` action
- `pdm/release` optional parts can now be detected and opted-in automatically