### PR TITLE
fix(pdm): ensure coverage comment handles `src`-layout and expose a `has_src` metadata (fix #137)

### DIFF
--- a/pdm/init/README.md
+++ b/pdm/init/README.md
@@ -33,5 +33,6 @@ jobs:
 | `has_docs` | Wether the project has a documentation exposed through the `doc` command |
 | `has_openapi` | Wether the project has an OpenAPI specification exposed through the `doc:openapi` command |
 | `has_docker` | Wether the project a Docker image (aka. a `Dockerfile` present at root) |
+| `has_src` | Wether the project is using a `src` layout or not |
 
 

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -41,6 +41,9 @@ outputs:
   has_docker:
     description: Wether the project a Docker image (aka. a `Dockerfile` present at root)
     value: ${{ steps.meta.outputs.has_docker }}
+  has_src:
+    description: Wether the project is using a `src` layout or not
+    value: ${{ steps.meta.outputs.has_src }}
 
 
 runs:
@@ -101,6 +104,9 @@ runs:
 
         [ -f Dockerfile ] && HAS_DOCKER='true' || HAS_DOCKER='false'
         echo "has_docker=${HAS_DOCKER}" >> $GITHUB_OUTPUT
+
+        [ -d src/ ] && HAS_SRC='true' || HAS_SRC='false'
+        echo "has_src=${HAS_SRC}" >> $GITHUB_OUTPUT
       shell: bash
     - name: Display commands output
       run: echo "${{ toJson(steps.meta.outputs) }}"

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -31,6 +31,7 @@ runs:
   steps:
     - name: Clone and install dependencies
       if: inputs.init == 'true'
+      id: meta
       uses: LedgerHQ/actions/pdm/init@main
       with:
         python-version: ${{ inputs.python-version }}
@@ -49,6 +50,7 @@ runs:
       uses: MishaKav/pytest-coverage-comment@v1.1.50
       with:
         github-token: ${{ inputs.github-token }}
+        coverage-path-prefix: ${{ steps.meta.outputs.has_src && 'src/' || '' }}
         pytest-xml-coverage-path: ./reports/coverage.xml
         junitxml-path: ./reports/tests.xml
         title: Coverage Report for Python ${{ inputs.python-version }}


### PR DESCRIPTION
This PR:
- fixes the coverage comments on PRs having broken links with `src`-based layouts
- expose a `has_src` helper in `pdm/init` outputs

Fixes #137