### PR TITLE
feat(pdm): failsafe PDM release (failsafe steps and cleanup on failure)

### DIFF
--- a/pdm/release/README.md
+++ b/pdm/release/README.md
@@ -23,6 +23,18 @@ jobs:
 | `group` | Dependency group(s) to install | `docs` | `false` |
 | `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
 
+## Environment variables
+
+### Publishing on Nexus
+
+Those variables are required if you want to publish you package on Nexus.
+
+| Name | Description | Default | Required |
+|------|-------------|---------|----------|
+| `NEXUS_HOST` | The Nexus repository host (without the `https?://` prefix) | | `true` |
+| `NEXUS_USER` | The Nexus username to authenticate with | | `true` |
+| `NEXUS_PASSWORD` | The Nexus password to authenticate with | | `true` |
+| `NEXUS_REPO` | The Nexus repository to publish in | `pypi-internal` | `false` |
 
 ## Outputs
 

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -76,6 +76,7 @@ runs:
       shell: bash
 
     - name: Push to GemFury
+      id: gemfury
       if: inputs.kind == 'lib' && env.PDM_PUBLISH_USERNAME != null
       env:
         PDM_PUBLISH_REPO: https://push.fury.io/ledger
@@ -86,9 +87,10 @@ runs:
       shell: bash
 
     - name: Push to our internal Nexus
+      id: nexus
       if: inputs.kind == 'lib' && env.NEXUS_HOST != null && env.NEXUS_USER != null && env.NEXUS_PASSWORD != null
       env:
-        PDM_PUBLISH_REPO: https://${{ env.NEXUS_HOST }}/repository/pypi-internal/
+        PDM_PUBLISH_REPO: https://${{ env.NEXUS_HOST }}/repository/${{ env.NEXUS_REPO || 'pypi-internal'}}/
         PDM_PUBLISH_USERNAME: ${{ env.NEXUS_USER }}
         PDM_PUBLISH_PASSWORD: ${{ env.NEXUS_PASSWORD }}
         FORCE_COLOR: true
@@ -107,12 +109,14 @@ runs:
 
     - name: Add docker image to release body
       if: steps.docker.outputs.image
+      continue-on-error: true  # Not critical
       run: |
         echo -e "\n**Docker image**: \`${{ steps.docker.outputs.image }}@${{ steps.docker.outputs.digest }}\`\n" >> body.md
       shell: bash
 
     - name: Documentation
       id: doc
+      continue-on-error: true  # Can be manually published after
       uses: LedgerHQ/actions/pdm/doc@main
       with:
         version: ${{ env.REVISION }}
@@ -123,6 +127,7 @@ runs:
 
     - name: Add doc to release body
       if: steps.doc.outputs.url
+      continue-on-error: true  # Not critical
       run: |
         echo -e "\n**Documentation**: <${{ steps.doc.outputs.url }}>\n" >> body.md
       shell: bash
@@ -135,6 +140,7 @@ runs:
 
     - name: Github Release
       id: release
+      continue-on-error: true  # Can be manually published after
       uses: softprops/action-gh-release@v2
       with:
         body_path: "body.md"
@@ -147,5 +153,65 @@ runs:
           CHANGELOG.md
 
     - name: Publish summary
+      continue-on-error: true
       run: echo "🚀 [Version ${{ env.REVISION }}](${{ steps.release.outputs.url }}) has been published" >> $GITHUB_STEP_SUMMARY
       shell: bash
+
+    # Cleanup published artifacts if tag push failed
+    - name: Show release failure in summary
+      # Runs on release failure if doc has been published
+      if: always() && job.status == 'failure'
+      run: |
+        echo "❌ Release ${REVISION} failed" >> $GITHUB_STEP_SUMMARY
+        echo "DIST=$(pdm show --name)" >> $GITHUB_ENV
+
+    - name: Cleanup documentation
+      # Runs on release failure if doc has been published
+      if: always() && job.status == 'failure' && steps.doc.outcome == 'success'
+      run: |
+        pdm run mike delete --push ${REVISION}
+        echo "🧹 Documentation for version ${REVISION} has been removed" >> $GITHUB_STEP_SUMMARY
+
+    - name: Cleanup docker
+      # Runs on release failure if docker has been published
+      if: always() && job.status == 'failure' && steps.docker.outcome == 'success'
+      run: |
+        # See:
+        #   - https://docs.github.com/en/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization
+        #   - https://docs.github.com/en/rest/packages/packages#delete-package-version-for-an-organization
+        GHAPI=("gh" "api" "-H" "Accept: application/vnd.github+json" "-H" "X-GitHub-Api-Version: 2022-11-28")
+        PKG='${{ github.event.repository.name }}'
+        VERSIONS=$(${GHAPI[@]} /orgs/LedgerHQ/packages/container/${PKG}/versions)
+        QUERY='.[] | select(.name == "${{ steps.docker.outputs.digest }}") | .id'
+        VERSION_ID=$(echo ${VERSIONS} | jq --raw-output ${QUERY})
+        ${GHAPI[@]} --method DELETE /orgs/LedgerHQ/packages/container/${PKG}/versions/${VERSION_ID}
+        IMAGE='${{ steps.docker.outputs.image }}@${{ steps.docker.outputs.digest }}'
+        echo "🧹 Docker image \`${IMAGE}\` has been deleted" >> $GITHUB_STEP_SUMMARY
+
+    - name: Cleanup Nexus
+      # Runs on release failure if package has been published on Nexus
+      if: always() && job.status == 'failure' && steps.nexus.outcome == 'success'
+      run: |
+        # See:
+        #   - https://help.sonatype.com/en/search-api.html#SearchAPI-SearchComponents
+        #   - https://help.sonatype.com/en/components-api.html#delete-component
+        API="https://${NEXUS_HOST}/service/rest/v1"
+        CURL=("curl" "-u" "${NEXUS_USER}:${NEXUS_PASSWORD}")
+        REPO=${NEXUS_REPO:-'pypi-internal'}
+        CANDIDATES=$(${CURL[@]} "${API}/search?repository=${REPO}&name=${DIST}&version=${REVISION}")
+        COMPONENT_ID=$(echo ${CANDIDATES} | jq --raw-output ".items[0].id")
+        ${CURL[@]} -X DELETE "${API}/components/${COMPONENT_ID}"
+        echo "🧹 Nexus package for \`${DIST}==${REVISION}\` have been deleted" >> $GITHUB_STEP_SUMMARY
+
+    - name: Cleanup GemFury
+      # Runs on release failure if package has been published to GemFury
+      if: always() && job.status == 'failure' && steps.gemfury.outcome == 'success'
+      run: |
+        # See:
+        #   - https://github.com/gemfury/cli/blob/main/api/yank.go
+        #   - https://github.com/gemfury/cli/blob/main/api/client.go
+        curl -X DELETE \
+             -H "Accept: application/vnd.fury.v1" \
+             -H "Authorization: ${{ inputs.pypi-token }}" \
+             https://api.fury.io/packages/${DIST}/versions/${REVISION}
+        echo "🧹 GemFury package \`${DIST}==${REVISION}\` have been deleted" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This PR make the `pdm/release` action more secure and avoid ending in an unstable state:
- not pushing the tag is considered a failure
- steps relying on CI-only credentials are considered critical (`gemfury`, `nexus`, `docker`):
  - can only be executed from CI
  - a release is considered failed as soon as one of them fail
  - they must be cleaned in the workflow (because they require credentials)
- documentation failure does not stop the release, as it can be published later from anybody with repository permissions
- GitHub release publication failure does not stop the process as it can be manually crafted after
- summary steps are should never make the workflow fail

On failure:
- docker image is deleted if any
- GemFury package is deleted if any
- Nexus package is deleted if any
- Tag Documentation is deleted if any
Those removals are added to the workflow summary.

In case of successful release but with failed steps, those can be manually repaired:
- documentation can be published by checking out the tag and executing `pdm doc:deploy --push <tag>`
- GitHub release can be created from the tag by copy-pasting the version changelog from `CHANGELOG.md`


With this, there should be o more partial release with manual cleanup to do.
