### PR TITLE
Pdm: support extra docker build args and secrets

### DIFF
--- a/pdm/docker/README.md
+++ b/pdm/docker/README.md
@@ -21,6 +21,7 @@ jobs:
 | `pypi-token` | A Token to Ledger private PyPI with read permissions | `""` | `true` |
 | `github-token` | A Github token with proper permissions | `""` | `false` |
 | `build-args` | Docker build command extra `build-args` (multiline supported) | `""` | `false` |
+| `secrets` | Docker build command extra `secrets` (multiline supported) | `""` | `false` |
 
 ## Outputs
 

--- a/pdm/docker/README.md
+++ b/pdm/docker/README.md
@@ -20,6 +20,7 @@ jobs:
 | `version` | Force the built version | `""` | `false` |
 | `pypi-token` | A Token to Ledger private PyPI with read permissions | `""` | `true` |
 | `github-token` | A Github token with proper permissions | `""` | `false` |
+| `build-args` | Docker build command extra `build-args` (multiline supported) | `""` | `false` |
 
 ## Outputs
 

--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -12,6 +12,9 @@ inputs:
     required: true
   github-token:
     description: A Github token with proper permissions
+  build-args:
+    description: Docker build command extra `build-args` (multiline supported)
+    default: ""
 
 
 outputs:
@@ -78,6 +81,7 @@ runs:
           VERSION=${{ steps.vars.outputs.version }}
           DD_GIT_REPOSITORY_URL=github.com/${{ github.repository }}
           DD_GIT_COMMIT_SHA=${{ github.sha }}
+          ${{ inputs.build-args }}
         secrets: |
           PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token }}
         pull: true
@@ -108,6 +112,7 @@ runs:
           VERSION=${{ steps.vars.outputs.version }}
           DD_GIT_REPOSITORY_URL=github.com/${{ github.repository }}
           DD_GIT_COMMIT_SHA=${{ github.sha }}
+          ${{ inputs.build-args }}
         secrets: |
           PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token }}
         pull: ${{ steps.vars.outputs.has_goss != 'true' }}

--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -15,6 +15,9 @@ inputs:
   build-args:
     description: Docker build command extra `build-args` (multiline supported)
     default: ""
+  secrets:
+    description: Docker build command extra `secrets` (multiline supported)
+    default: ""
 
 
 outputs:
@@ -84,6 +87,7 @@ runs:
           ${{ inputs.build-args }}
         secrets: |
           PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token }}
+          ${{ inputs.secrets }}
         pull: true
         load: true
         tags: ${{ steps.meta.outputs.tags }}
@@ -115,6 +119,7 @@ runs:
           ${{ inputs.build-args }}
         secrets: |
           PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token }}
+          ${{ inputs.secrets }}
         pull: ${{ steps.vars.outputs.has_goss != 'true' }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This PR adds support for extra `build-args` and `secrets` parameters to the Docker build command