### PR TITLE
feat(pdm): support `dgoss` extra parameters

### DIFF
--- a/pdm/docker/README.md
+++ b/pdm/docker/README.md
@@ -22,6 +22,7 @@ jobs:
 | `github-token` | A Github token with proper permissions | `""` | `false` |
 | `build-args` | Docker build command extra `build-args` (multiline supported) | `""` | `false` |
 | `secrets` | Docker build command extra `secrets` (multiline supported) | `""` | `false` |
+| `dgoss-args` | `dgoss` extra docker parameters | `""` | `false` |
 
 ## Outputs
 

--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -18,6 +18,9 @@ inputs:
   secrets:
     description: Docker build command extra `secrets` (multiline supported)
     default: ""
+  dgoss-args:
+    description: dgoss extra docker parameters
+    default: ""
 
 
 outputs:
@@ -100,7 +103,7 @@ runs:
       if: steps.vars.outputs.has_goss == 'true'
 
     - name: Run GOSS validation
-      run: dgoss run ghcr.io/ledgerhq/${{ github.event.repository.name }}:${DOCKER_METADATA_OUTPUT_VERSION}
+      run: dgoss run ${{ inputs.dgoss-args }} ghcr.io/ledgerhq/${{ github.event.repository.name }}:${DOCKER_METADATA_OUTPUT_VERSION}
       if: steps.vars.outputs.has_goss == 'true'
       env:
         # Make dgoss works with Ledger dind runners


### PR DESCRIPTION
Provide support for optional extra `dgoss` parameters (docker run arguments while run the `goss`/`dgoss` test).