### PR TITLE
Factorize OpenAPI diff and integrate it to `pdm/doc/build` action

### DIFF
--- a/openapi/README.md
+++ b/openapi/README.md
@@ -1,0 +1,9 @@
+# OpenAPI-related actions
+
+Provides some reusable OpenAPI actions.
+
+## Actions
+
+| Name | Description |
+|--------|-------------|
+| [OpenAPI Diff (`diff`)](diff/) | Generate a diff between 2 OpenAPI specifications |

--- a/openapi/diff/README.md
+++ b/openapi/diff/README.md
@@ -1,0 +1,28 @@
+# OpenAPI Diff
+
+Generate a diff between 2 OpenAPI specifications
+
+## Usage
+
+```yaml
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/openapi/diff@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `base` | Base diff specification file | `""` | `true` |
+| `head` | Head diff specification file | `""` | `true` |
+| `output` | Output directory | `reports/openapi` | `true` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `markdown` | Path to the generated markdown diff file |
+| `text` | Path to the generated text diff file |

--- a/openapi/diff/action.yml
+++ b/openapi/diff/action.yml
@@ -1,0 +1,82 @@
+name: OpenAPI Diff
+description: Generate a diff between 2 OpenAPI specifications
+
+inputs:
+  base:
+    description: Base diff specification file
+    required: true
+  head:
+    description: Head diff specification file
+    required: true
+  output:
+    description: Output directory
+    required: true
+    default: reports/openapi
+
+outputs:
+  markdown:
+    description: Path to the generated markdown diff file
+    value: ${{ steps.generate.outputs.markdown }}
+  text:
+    description: Path to the generated text diff file
+    value: ${{ steps.generate.outputs.text }}
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+
+    - name: Install bump CLI
+      run: |
+        npm install -g bump-cli
+      shell: bash
+
+    - name: Create outputs directory
+      run: |
+        mkdir -p ${{ inputs.output }}
+      shell: bash
+
+    - name: generate diff files (markdown & plain text)
+      id: generate
+      run: |
+        # see https://github.com/bump-sh/cli/blob/main/src/flags.ts#L94
+        # the CI env variable is automatically in Github action
+        # we do not want to fails on breaking change
+        # but we want to stop if the diff fail for other reasons
+        unset CI
+
+        echo "Generating Markdown diff"
+        md_output=${{ inputs.output }}/diff.md
+        bump diff -f markdown ${{ inputs.base }} ${{ inputs.head }} > ${md_output}
+        echo "markdown=${md_output}" >> "$GITHUB_OUTPUT"
+
+        # Format diff has PR comment
+        comment=${{ inputs.output }}/pr-comment.md
+        echo "## OpenAPI changes\n" >> ${comment}
+        cat ${md_output} >> ${comment}
+        echo "comment=${comment}" >> "$GITHUB_OUTPUT"
+        # Display diff in the summary
+        cat ${comment} >> $GITHUB_STEP_SUMMARY
+
+        echo "Generating text diff"
+        txt_output=${{ inputs.output }}/diff.txt
+        bump diff -f txt ${{ inputs.base }} ${{ inputs.head }} > ${txt_output}
+        echo "text=${txt_output}" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Comment PR with OpenAPI diff
+      if: github.event_name == 'pull_request'
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        filePath: ${{ steps.generate.outputs.comment }}
+        comment_tag: openapi-diff
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: openapi-diff
+        path: |
+          ${{ steps.generate.outputs.markdown }}
+          ${{ steps.generate.outputs.text }}
+        retention-days: 10

--- a/pdm/doc/build/action.yml
+++ b/pdm/doc/build/action.yml
@@ -30,6 +30,7 @@ runs:
   steps:
     - name: Clone and install dependencies
       uses: LedgerHQ/actions/pdm/init@main
+      id: init
       if: inputs.init == 'true'
       with:
         group: ${{ inputs.group }}
@@ -80,3 +81,32 @@ runs:
         path: site/
         retention-days: 7
         if-no-files-found: error
+
+    - name: Backup current OpenAPI specifications
+      if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      run: mv docs/openapi.yaml openapi.head.yaml
+      shell: bash
+
+    - name: Checkout base ref
+      if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      run: git checkout ${{ github.base_ref }}
+      shell: bash
+
+    - name: Synchronize dependencies
+      if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      run: pdm sync
+      shell: bash
+
+    - name: Generate the base OpenAPI specifications
+      if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      run: pdm doc:openapi
+      env:
+        FORCE_COLOR: 'true'
+      shell: bash
+
+    - name: Generate the OpenAPI diff
+      if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      uses: LedgerHQ/actions/openapi/diff@main
+      with:
+        base: openapi.base.yaml
+        head: openapi.head.yaml

--- a/pdm/init/README.md
+++ b/pdm/init/README.md
@@ -33,3 +33,4 @@ jobs:
 | `has_openapi` | Whether the project has an OpenAPI specification exposed through the `doc:openapi` command |
 | `has_docker` | Whether the project a Docker image (aka. a `Dockerfile` present at root) |
 | `has_src` | Whether the project is using a `src` layout or not |
+| `is_pr` | Is the current workflow run a pull-request |

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -44,6 +44,9 @@ outputs:
   has_src:
     description: Whether the project is using a `src` layout or not
     value: ${{ steps.meta.outputs.has_src }}
+  is_pr:
+    description: Is the current workflow run a pull-request
+    value: ${{ steps.meta.outputs.is_pr }}
 
 
 runs:
@@ -107,7 +110,7 @@ runs:
 
         [ -d src/ ] && HAS_SRC='true' || HAS_SRC='false'
         echo "has_src=${HAS_SRC}" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: Display commands output
-      run: echo "${{ toJson(steps.meta.outputs) }}"
+
+        IS_PR="${{ github.event_name == 'pull_request' }}"
+        echo "is_pr=${IS_PR}" >> $GITHUB_OUTPUT
       shell: bash

--- a/python-app/openapi-diff/action.yaml
+++ b/python-app/openapi-diff/action.yaml
@@ -109,39 +109,9 @@ runs:
         cp ${{ inputs.doc_output }} ./specs/head-spec.yaml
       shell: bash
 
-    - name: Use Node.js
-      uses: actions/setup-node@v3
-
-    - name: install bump CLI
-      run: |
-        npm install -g bump-cli
-      shell: bash
-
-    - name: create outputs directory
-      run: |
-        mkdir outputs
-      shell: bash
-
-    - name: generate markdown diff
-      run: |
-        # see https://github.com/bump-sh/cli/blob/main/src/flags.ts#L94
-        # the CI env variable is automatically in Github action
-        # we do not want to fails on breaking change
-        # but we want to stop if the diff fail for other reasons
-        unset CI
-        bump diff -f markdown ./specs/base-spec.yaml ./specs/head-spec.yaml > outputs/spec-diff.md
-        bump diff -f text ./specs/base-spec.yaml ./specs/head-spec.yaml > outputs/spec-diff.text
-      shell: bash
-
-    - name: Comment PR with OpenAPI diff
-      uses: thollander/actions-comment-pull-request@v2
-      if: github.event_name == 'pull_request'
+    - name: Generate the OpenAPI diff
+      uses: LedgerHQ/actions/openapi/diff@main
       with:
-        filePath: outputs/spec-diff.md
-        comment_tag: openapi-diff
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: openapi-diff
-        path: outputs
-        retention-days: 10
+        base: specs/base-spec.yaml
+        head: specs/head-spec.yaml
+        output: outputs/


### PR DESCRIPTION
Extract the pure OpenAPI diff part into its own `openapi/diff` action.
Adds OpenAPI diff generation to `pdm/doc/build` action if this is a pull-request