### PR TITLE
feat: multi-arch build for python-app

### DIFF
--- a/python-app/docker/action.yml
+++ b/python-app/docker/action.yml
@@ -72,11 +72,9 @@ runs:
 
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Set up Docker Buildx
-      env:
-        PLATFORMS: ${{ inputs.PLATFORMS || 'linux/amd64' }}
       uses: docker/setup-buildx-action@v3
       with:
-        platforms: $PLATFORMS
+        platforms: ${{ inputs.PLATFORMS || 'linux/amd64' }}
 
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Build and push

--- a/python-app/docker/action.yml
+++ b/python-app/docker/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "args to pass to docker build"
     required: false
     default: ""
+  platforms:
+    description: "args for build platforms (eg: linux/amd64,linux/arm64)"
+    required: false
+    default: linux/amd64 
 
 outputs:
   version:
@@ -74,7 +78,7 @@ runs:
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
-        platforms: ${{ inputs.PLATFORMS || 'linux/amd64' }}
+        platforms: ${{ inputs.platforms }}
 
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Build and push

--- a/python-app/docker/action.yml
+++ b/python-app/docker/action.yml
@@ -72,9 +72,11 @@ runs:
 
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Set up Docker Buildx
+      env:
+        PLATFORMS: ${{ inputs.PLATFORMS || 'linux/amd64' }}
       uses: docker/setup-buildx-action@v3
       with:
-        platforms: linux/amd64,linux/arm64
+        platforms: $PLATFORMS
 
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Build and push

--- a/python-app/docker/action.yml
+++ b/python-app/docker/action.yml
@@ -73,6 +73,8 @@ runs:
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
 
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Build and push

--- a/python-app/docker/action.yml
+++ b/python-app/docker/action.yml
@@ -9,7 +9,7 @@ inputs:
   platforms:
     description: "args for build platforms (eg: linux/amd64,linux/arm64)"
     required: false
-    default: linux/amd64 
+    default: linux/amd64
 
 outputs:
   version:


### PR DESCRIPTION
**Still requires testing please do not merge until is properly tested**

This will allow to build and push [multi-arch docker images](https://github.blog/changelog/2020-09-17-github-container-registry-support-for-multi-arch-images/) in order to support running on non-intel machines. 

This change is supported by the [github action docker-setup-buildx](https://github.com/marketplace/actions/docker-setup-buildx#customizing)

