### PR TITLE
fix(pdm): fix the OpenAPI diff

### DIFF
--- a/pdm/doc/build/action.yml
+++ b/pdm/doc/build/action.yml
@@ -89,7 +89,10 @@ runs:
 
     - name: Checkout base ref
       if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
-      run: git checkout ${{ github.base_ref }}
+      run: |
+        # Clean dirty state before trying to switch branch
+        git restore .
+        git checkout ${{ github.base_ref }}
       shell: bash
 
     - name: Synchronize dependencies

--- a/pdm/doc/build/action.yml
+++ b/pdm/doc/build/action.yml
@@ -84,11 +84,13 @@ runs:
 
     - name: Backup current OpenAPI specifications
       if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      continue-on-error: true  # OpenAPI diff is optional
       run: mv docs/openapi.yaml openapi.head.yaml
       shell: bash
 
     - name: Checkout base ref
-      if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      if: success() && steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      continue-on-error: true  # OpenAPI diff is optional
       run: |
         # Clean dirty state before trying to switch branch
         git restore .
@@ -96,19 +98,22 @@ runs:
       shell: bash
 
     - name: Synchronize dependencies
-      if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      if: success() && steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      continue-on-error: true  # OpenAPI diff is optional
       run: pdm sync
       shell: bash
 
     - name: Generate the base OpenAPI specifications
-      if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      if: success() && steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      continue-on-error: true  # OpenAPI diff is optional
       run: pdm doc:openapi
       env:
         FORCE_COLOR: 'true'
       shell: bash
 
     - name: Generate the OpenAPI diff
-      if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      if: success() && steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
+      continue-on-error: true  # OpenAPI diff is optional
       uses: LedgerHQ/actions/openapi/diff@main
       with:
         base: openapi.base.yaml


### PR DESCRIPTION
This PRs:
- ensures that we can switch on the reference branch when performing the OpenAPI diff when there are some changes on the working copy (eg. `CHANGELOG.md`)
- ensures that the entire OpenAPI diff is non required to mark a workflow as succeed because there are many reasons that would prevent to make a diff with the base branch:
  - OpenAPI generation is broken on the base branch (and PR is trying to fix it)
  - the base branch does not have OpenAPI specs generation (because PR is adding it)