### PR TITLE
fix(pdm): fix bad quoting in `pdm/test` action

### DIFF
--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -103,7 +103,7 @@ runs:
       shell: bash
 
     - name: Send coverage report to Backstage
-      if: steps.meta.outputs.has_backstage && env.BACKSTAGE_URL && github.ref_name == "main"
+      if: steps.meta.outputs.has_backstage && env.BACKSTAGE_URL && github.ref_name == 'main'
       continue-on-error: true  # Not critical
       run: |
         # See:


### PR DESCRIPTION
Fix bad GitHub expression string quoting (only accept single quotes)