### PR TITLE
Fixes Allure report name in `pdm/test`

### DIFF
--- a/pdm/init/README.md
+++ b/pdm/init/README.md
@@ -36,3 +36,4 @@ jobs:
 | `has_src` | Whether the project is using a `src` layout or not |
 | `has_backstage` | Whether the project is exposing Backstage catalog infos |
 | `is_pr` | Is the current workflow run a pull-request |
+| `branch` | The branch from which workflow has been triggered |

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -28,7 +28,7 @@ inputs:
 outputs:
   identifier:
     description: The short project identifier
-    value: ${{ steps.meta.output.identifier }}
+    value: ${{ steps.meta.outputs.identifier }}
   has_tests:
     description: Whether the project has tests exposed through the `test` command
     value: ${{ steps.meta.outputs.has_tests }}

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -53,6 +53,9 @@ outputs:
   is_pr:
     description: Is the current workflow run a pull-request
     value: ${{ steps.meta.outputs.is_pr }}
+  branch:
+    description: The branch from which workflow has been triggered
+    value: ${{ steps.meta.outputs.branch }}
 
 
 runs:
@@ -98,6 +101,7 @@ runs:
       id: meta
       run: |
         echo "identifier=$(pdm show --name)" >> $GITHUB_OUTPUT
+        echo "branch=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
 
         COMMANDS=$(pdm run --json)
 

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -72,7 +72,7 @@ runs:
       run: |
         [ -d reports/allure ] && REPORT='true' || REPORT='false'
         echo "has_report=${REPORT}" >> $GITHUB_OUTPUT
-        echo "path_suffix=${{ github.ref_name == 'main' && '' || format('@{0}', github.ref_name) }}" >> $GITHUB_OUTPUT
+        echo "path_suffix=${{ github.ref_name == 'main' && '' || format('@{0}', steps.meta.outputs.branch) }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Publish Allure report

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -75,6 +75,29 @@ runs:
         echo "path_suffix=${{ github.ref_name == 'main' && '' || format('@{0}', steps.meta.outputs.branch) }}" >> $GITHUB_OUTPUT
       shell: bash
 
+    - name: Generate Allure environment file
+      if: steps.check-allure.outputs.has_report && inputs.allure-username && inputs.allure-password
+      continue-on-error: true
+      run: |
+        ENV_FILE=reports/allure/environment.properties
+        echo "language = python"
+        echo "python_version = ${{ inputs.python-version }}" >> $ENV_FILE
+        echo "os = ${{ runner.os }}" >> $ENV_FILE
+        echo "arch = ${{ runner.arch }}" >> $ENV_FILE
+        echo "github_runner = ${{ runner.name }}" >> $ENV_FILE
+        echo "github_runner_env = ${{ runner.environment }}" >> $ENV_FILE
+        echo "repository = ${{ github.repository }}" >> $ENV_FILE
+        echo "branch = ${{ steps.meta.outputs.branch }}" >> $ENV_FILE
+        echo "commit = ${{ github.sha }}" >> $ENV_FILE
+        echo "actor = ${{ github.triggering_actor }}" >> $ENV_FILE
+        if [ "${{ steps.meta.outputs.is_pr }}" == "true" ]; then
+          echo "pull_request = https://github.com/${{ github.repository }}/pull/${{ github.event.number }}" >> $ENV_FILE
+        fi
+        if [ "${{ github.ref_type }}" == "tag" ]; then
+          echo "tag = ${{ github.ref_name }}" >> $ENV_FILE
+        fi
+      shell: bash
+
     - name: Publish Allure report
       id: allure
       if: steps.check-allure.outputs.has_report && inputs.allure-username && inputs.allure-password


### PR DESCRIPTION
Fix Allure report name:
- fix typo in `pdm/init` `identifier` output
- add `branch` output to `pdm/init`
- use the resolved branch in allure report path

Bonus: add an environment file for Allure to parse (includes all run metadata as well as the PR deep link if any)

Sample report: https://vault.allure.green.ledgerlabs.net/allure/reports/805ddd59-06e8-4f52-b2f0-226f5675b8c1/index.html (miss `branch` which is part of this PR)