### PR TITLE
Small adjustments

### DIFF
--- a/openapi/diff/action.yml
+++ b/openapi/diff/action.yml
@@ -56,7 +56,7 @@ runs:
 
         # Format diff has PR comment
         comment=${{ inputs.output }}/pr-comment.md
-        echo "## OpenAPI changes\n" >> ${comment}
+        echo "## OpenAPI changes" >> ${comment}
         cat ${md_output} >> ${comment}
         echo "comment=${comment}" >> "$GITHUB_OUTPUT"
         # Display diff in the summary

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -72,7 +72,6 @@ runs:
       run: |
         [ -d reports/allure ] && REPORT='true' || REPORT='false'
         echo "has_report=${REPORT}" >> $GITHUB_OUTPUT
-        echo "path_suffix=${{ github.ref_name == 'main' && '' || format('@{0}', steps.meta.outputs.branch) }}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Generate Allure environment file
@@ -109,7 +108,7 @@ runs:
         build-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         username: ${{ inputs.allure-username }}
         password: ${{ inputs.allure-password }}
-        path: ${{ steps.meta.outputs.identifier }}${{ steps.check-allure.outputs.path_suffix }}
+        path: ${{ steps.meta.outputs.identifier }}@${{ steps.meta.outputs.branch }}
         allure-results: reports/allure
 
     - name: Add Allure report link to the pull-request


### PR DESCRIPTION
- remove the visible `\n` from OpenAPI diff comment
- always keep the `@<branch>` suffix (was already the case due to a bug, so keep it as it is actually useful)