### PR TITLE
fix(pdm): release requires dgoss-args too

### DIFF
--- a/pdm/release/README.md
+++ b/pdm/release/README.md
@@ -23,6 +23,7 @@ jobs:
 | `group` | Dependency group(s) to install | `docs` | `false` |
 | `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
 | `public` | Is it a public library ? | `false` | `false` |
+| `dgoss-args` | `dgoss` extra docker parameters | `""` | `false` |
 
 ## Environment variables
 

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -25,6 +25,9 @@ inputs:
   public:
     description: Is it a public library ?
     default: 'false'
+  dgoss-args:
+    description: dgoss extra docker parameters
+    default: ""
 
 
 
@@ -119,6 +122,7 @@ runs:
         version: ${{ env.REVISION }}
         pypi-token: ${{ inputs.pypi-token }}
         github-token: ${{ inputs.github-token }}
+        dgoss-args: ${{ inputs.dgoss-args }}
 
     - name: Add docker image to release body
       if: steps.docker.outputs.image


### PR DESCRIPTION
Given release check docker image using `goss`/`dgoss`, it also requires `dgoss-args` too.