### PR TITLE
PDM: Support for matrix testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -436,6 +436,18 @@ updates:
       prefix: "ci"
       include: "scope"
   -
+    # Maintain dependencies for allure/generate
+    package-ecosystem: github-actions
+    directory: /allure/generate
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: ci
+      include: scope
+  -
     # Maintain dependencies for allure/publish
     package-ecosystem: github-actions
     directory: /allure/publish
@@ -447,6 +459,18 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+  -
+    # Maintain dependencies for allure/upload
+    package-ecosystem: github-actions
+    directory: /allure/upload
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: ci
+      include: scope
   -
     # Maintain dependencies for helm/conform
     package-ecosystem: github-actions

--- a/allure/generate/README.md
+++ b/allure/generate/README.md
@@ -1,0 +1,43 @@
+# Generate Allure report
+
+Generate an allure report for a set of results (given their uuids)
+
+## Usage
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/allure/upload@main
+        with:
+          url: https://allure.server.url
+          build-name: ${{ github.workflow }}
+          build-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          username: ${{ secrets.allure-username }}
+          password: ${{ secrets.allure-password }}
+          path: my-project
+          results: allure-results
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `url` | Full url of your deployed allure-server' | `""` | `true` |
+| `username` | If your allure-server has basic auth enabled, specify username here | `""` | `false` |
+| `password` | If your allure-server has basic auth enabled, specify password here | `""` | `false` |
+| `path` | Allure server identifier used to aggregate reports (default to repository name) | `""` | `true` |
+| `results` | line separated list of results UUIDs to process | `""` | `true` |
+| `report-name` | [Report Overview top name](https://allurereport.org/docs/how-it-works-executor-file/#report-properties) *(default to `<repository name>`)* | `""` | `false` |
+| `build-name` | [Executor](https://allurereport.org/docs/how-it-works-executor-file/) build name *(default to `<workflow name> #<buildno>`)* | `""` | `false` |
+| `build-url` | [Executor](https://allurereport.org/docs/how-it-works-executor-file/#build-properties) link to the build *(default to the current workflow run URL)* | `""` | `false` |
+| `delete-results` | Whether or not to delete the raw results after the report generation. | `true` | `false` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `response` | The Allure Server generation JSON response |
+| `uuid` | The generated report UUID |
+| `url` | The generated report unique URL |

--- a/allure/generate/action.yml
+++ b/allure/generate/action.yml
@@ -1,0 +1,102 @@
+name: Generate Allure report
+description: Generate an allure report for a set of results (given their uuids)
+
+inputs:
+  url:
+    description: Full url of your deployed allure-server'
+    required: true
+  username:
+    description: 'If your allure-server has basic auth enabled, specify username here'
+    required: false
+  password:
+    description: 'If your allure-server has basic auth enabled, specify password here'
+    required: false
+  path:
+    description: Allure server identifier used to aggregate reports (default to repository name)
+    required: true
+  results:
+    description: line separated list of results UUIDs to process
+    required: true
+  report-name:
+    description: >
+      [Report Overview top name](https://allurereport.org/docs/how-it-works-executor-file/#report-properties)
+      *(default to `<repository name>`)*
+    required: false
+  build-name:
+    description: >
+      [Executor](https://allurereport.org/docs/how-it-works-executor-file/) build name
+      *(default to `<workflow name> #<buildno>`)*
+    required: false
+  build-url:
+    description: >
+      [Executor](https://allurereport.org/docs/how-it-works-executor-file/#build-properties) link to the build
+      *(default to the current workflow run URL)*
+    required: false
+  delete-results:
+    description: Whether or not to delete the raw results after the report generation.
+    default: "true"
+    required: false
+
+outputs:
+  response:
+    description: The Allure Server generation JSON response
+    value: ${{ steps.generate.outputs.response }}
+  uuid:
+    description: The generated report UUID
+    value: ${{ steps.generate.outputs.uuid }}
+  url:
+    description: The generated report unique URL
+    value: ${{ steps.generate.outputs.url }}
+
+runs:
+  using: composite
+  steps:
+
+    - name: Format UUIDs list
+      id: uuids
+      run: |
+        : Format UUIDs list
+        echo "json<<EOF" >> $GITHUB_OUTPUT
+        echo "${RESULTS}" | jq -nR "[inputs]" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+      env:
+        RESULTS: ${{ inputs.results }}
+      shell: bash
+
+    - name: Generate report
+      id: generate
+      run: |
+        : Generate report
+        response=$(\
+          curl -X POST '${{ inputs.url }}/api/report' \
+          --location --no-progress-meter \
+          --header 'Content-Type: application/json' \
+          --user '${{ inputs.username }}:${{ inputs.password }}' \
+          --data-raw '{
+            "reportSpec": {
+              "path": ["${{ inputs.path }}"],
+              "executorInfo": {
+                "name": "GitHub",
+                "type": "github",
+                "reportName": "${{ inputs.report-name || github.event.repository.name }}",
+                "buildName": "${{ inputs.build-name || env.DEFAULT_BUILD_NAME }}",
+                "buildUrl": "${{ inputs.build-url || env.DEFAULT_BUILD_URL }}"
+              }
+            },
+            "results": ${{ steps.uuids.outputs.json }},
+            "deleteResults": ${{ inputs.delete-results }}
+          }' \
+        )
+        UUID=$(echo "${response}" | jq -r .uuid)
+        REPORT_URL=$(echo "${response}" | jq -r .url)
+
+        echo "response<<EOF" >> $GITHUB_OUTPUT
+        echo "${response}" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+        echo "uuid=${UUID}" >> $GITHUB_OUTPUT
+        echo "url=${REPORT_URL}" >> $GITHUB_OUTPUT
+        echo "📊 Generated report ${UUID}: ${REPORT_URL}"
+      env:
+        DEFAULT_BUILD_NAME: "${{ github.workflow }} #${{ github.run_number }}"
+        DEFAULT_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      shell: bash

--- a/allure/upload/README.md
+++ b/allure/upload/README.md
@@ -1,0 +1,29 @@
+# Upload to Allure server
+
+Upload some Allure results to an Allure Server instance
+
+## Usage
+
+```yaml
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/allure/upload@main
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `url` | Allure Server root url | `""` | `true` |
+| `username` | Allure Server authentication username (Basic Auth) | `""` | `true` |
+| `password` | Allure Server authentication password (Basic Auth) | `""` | `true` |
+| `results` | Path to the Allure results directory to upload | `allure-result` | `false` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `response` | The Allure Server upload JSON response |
+| `uuid` | The result upload unique identifier |

--- a/allure/upload/action.yml
+++ b/allure/upload/action.yml
@@ -1,0 +1,56 @@
+name: Upload to Allure server
+description: Upload some Allure results to an Allure Server instance
+
+inputs:
+  url:
+    description: Allure Server root url
+    required: true
+  username:
+    description: Allure Server authentication username (Basic Auth)
+    required: true
+  password:
+    description: Allure Server authentication password (Basic Auth)
+    required: true
+  results:
+    description: Path to the Allure results directory to upload
+    required: false
+    default: allure-result
+
+outputs:
+  response:
+    description: The Allure Server upload JSON response
+    value: ${{ steps.upload.outputs.response }}
+  uuid:
+    description: The result upload unique identifier
+    value: ${{ steps.upload.outputs.uuid }}
+
+runs:
+  using: composite
+  steps:
+
+    - name: Zip Allure results
+      run: |
+        : Zip Allure results
+        cd ${{ inputs.results }} && zip -r ${{ github.workspace }}/allure.zip *
+      shell: bash
+
+    - name: Upload Allure results
+      id: upload
+      run: |
+        : Upload Allure results
+        response=$(\
+          curl -X POST '${{ inputs.url }}/api/result' \
+          --no-progress-meter \
+          --header  "accept: */*" \
+          --header  "Content-Type: multipart/form-data" \
+          --user '${{ inputs.username }}:${{ inputs.password }}' \
+          --form "allureResults=@allure.zip;type=application/x-zip-compressed" \
+        )
+        UUID=$(echo "${response}" | jq -r .uuid)
+
+        echo "response<<EOF" >> $GITHUB_OUTPUT
+        echo "${response}" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+        echo "uuid=${UUID}" >> $GITHUB_OUTPUT
+        echo "📊 Uploaded result ${UUID}"
+      shell: bash

--- a/pdm/init/README.md
+++ b/pdm/init/README.md
@@ -22,6 +22,7 @@ jobs:
 | `history` | Fetch the full history | `false` | `false` |
 | `pypi-token` | Private PyPI token (read) | `""` | `false` |
 | `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
+| `skip-dependencies` | Skip dependencies installation | `""` | `false` |
 
 ## Outputs
 

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -24,6 +24,8 @@ inputs:
     description: A Github token with proper permissions
     required: false
     default: ${{ github.token }}
+  skip-dependencies:
+    description: Skip dependencies installation
 
 outputs:
   identifier:
@@ -69,6 +71,7 @@ runs:
 
     - name: Setup git
       run: |
+        : Setup git
         git config user.name github-actions
         git config user.email github-actions@ledger.fr
       shell: bash
@@ -81,11 +84,14 @@ runs:
 
     - name: Set some settings
       run: |
+        : Set some settings
         pdm config install.cache true
       shell: bash
 
     - name: Install dependencies (main, all extras and specified dev group)
+      if: inputs.skip-dependencies == null
       run: |
+        : Install dependencies
         echo "${{ github.workspace }}/.venv/bin/python" > .pdm-python
         params=(--group :all --dev)
         [ -z "${GROUPS}" ] || params+=(--group ${GROUPS})
@@ -100,6 +106,7 @@ runs:
     - name: Extract some metadata
       id: meta
       run: |
+        : Extract some metadata
         echo "identifier=$(pdm show --name)" >> $GITHUB_OUTPUT
         echo "branch=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
 

--- a/pdm/test/README.md
+++ b/pdm/test/README.md
@@ -23,14 +23,18 @@ jobs:
 | `parameters` | Some extra parameters to pass to `pdm cover` | `""` | `false` |
 | `group` | Dependency group(s) to install | `test` | `false` |
 | `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
-| `allure-username` | Allure username (requires both username and password to enable Allure) | `""` | `false` |
-| `allure-password` | Allure password (requires both username and password to enable Allure) | `""` | `false` |
+| `matrix-id` | An optional unique ID for matrix builds (triggers parallelism) | `""` | `false` |
+| `report-only` | Only perform aggregation and reporting (parallelism closure) | `""` | `false` |
 
 ## Environment variables
 
 | Variable | Description |
-|----------|-------------|
+|--------|-------------|
 | `BACKSTAGE_URL` | URL to an optional Backstage instance to upload coverage to |
+| `ALLURE_URL` | URL to an optional Allure instance to upload test results to |
+| `ALLURE_USERNAME` | Allure instance authentication username |
+| `ALLURE_PASSWORD` | Allure instance authentication password |
+| `ALLURE_UUIDS` | Allure results UUIDS in case of matrix testing |
 
 ## Outputs
 

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -25,12 +25,10 @@ inputs:
   exclude-group:
     description: Dependency group(s) to exclude from install
     default: ''
-  allure-username:
-    description: Allure username (requires both username and password to enable Allure)
-    default: ''
-  allure-password:
-    description: Allure password (requires both username and password to enable Allure)
-    default: ''
+  matrix-id:
+    description: An optional unique ID for matrix builds (triggers parallelism)
+  report-only:
+    description: Only perform aggregation and reporting (parallelism closure)
 
 runs:
   using: composite
@@ -44,90 +42,192 @@ runs:
         group: ${{ inputs.group }}
         exclude-group: ${{ inputs.exclude-group }}
         pypi-token: ${{ inputs.pypi-token }}
+        skip-dependencies: ${{ inputs.report-only }}
 
-    - name: Run Tests
-      run: pdm cover -v --force-sugar --color=yes ${{ inputs.parameters }}
-      env:
-        FORCE_COLOR: 'true'
+    - name: Compute unique matrix hashable ID
+      if: inputs.matrix-id
+      id: matrix-meta
+      run: |
+        : Compute unique matrix hashable ID
+        # Generate a unique hash for each matrix path test path
+        id=$(echo "${{ inputs.matrix-id }}" | sha256sum | cut -c 1-8)
+        echo "id=${id}" >> $GITHUB_OUTPUT
+        echo "suffix=.${id}" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Pytest coverage comment
-      id: coverage
-      uses: MishaKav/pytest-coverage-comment@v1.1.52
-      with:
-        github-token: ${{ inputs.github-token }}
-        coverage-path-prefix: ${{ steps.meta.outputs.has_src == 'true' && 'src/' || '' }}
-        pytest-xml-coverage-path: ./reports/coverage.xml
-        junitxml-path: ./reports/tests.xml
-        title: Coverage Report for Python ${{ inputs.python-version }}
-        unique-id-for-comment: ${{ inputs.python-version }}
-
-    - name: Add coverage report to summary
-      run: echo -e ${{ steps.coverage.outputs.summaryReport }} >> $GITHUB_STEP_SUMMARY
+    - name: Run tests
+      if: inputs.report-only == null
+      run: |
+        : Run tests
+        pdm cover -v --force-sugar --color=yes ${{ inputs.parameters }}
+      env:
+        FORCE_COLOR: 'true'
+        COVERAGE_FILE: reports/coverage${{ inputs.matrix-id && steps.matrix-meta.outputs.suffix || '' }}.data
+        COVERAGE_XML: reports/coverage${{ inputs.matrix-id && steps.matrix-meta.outputs.suffix || '' }}.xml
+        JUNIT_XML: reports/junit${{ inputs.matrix-id && steps.matrix-meta.outputs.suffix || '' }}.xml
       shell: bash
 
     - name: Detect Allure report presence
       id: check-allure
+      if: inputs.report-only == null
       continue-on-error: true
       run: |
-        [ -d reports/allure ] && REPORT='true' || REPORT='false'
+        : Detect Allure report presence
+        [ -d reports/allure ] && REPORT='true' || REPORT=''
+        [ "${{ env.ALLURE_USERNAME && env.ALLURE_PASSWORD }}" != "" ] && CREDENTIALS='true' || CREDENTIALS=''
+        [ "${REPORT}${CREDENTIALS}" == "truetrue" ] && ALLURE='true' || ALLURE=''
+
         echo "has_report=${REPORT}" >> $GITHUB_OUTPUT
+        echo "has_credentials=${CREDENTIALS}" >> $GITHUB_OUTPUT
+        echo "has_allure=${ALLURE}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Generate Allure environment file
-      if: steps.check-allure.outputs.has_report == 'true' && inputs.allure-username && inputs.allure-password
+      if: steps.check-allure.outputs.has_allure
       continue-on-error: true
       run: |
+        : Generate Allure environment file
         ENV_FILE=reports/allure/environment.properties
-        echo "language = python"
+        echo "language = python" >> $ENV_FILE
         echo "python_version = ${{ inputs.python-version }}" >> $ENV_FILE
         echo "os = ${{ runner.os }}" >> $ENV_FILE
         echo "arch = ${{ runner.arch }}" >> $ENV_FILE
         echo "github_runner = ${{ runner.name }}" >> $ENV_FILE
         echo "github_runner_env = ${{ runner.environment }}" >> $ENV_FILE
         echo "repository = ${{ github.repository }}" >> $ENV_FILE
-        echo "branch = ${{ steps.meta.outputs.branch }}" >> $ENV_FILE
+        echo "${{ github.ref_type }} = ${{ github.head_ref || github.ref_name }}" >> $ENV_FILE
         echo "commit = ${{ github.sha }}" >> $ENV_FILE
         echo "actor = ${{ github.triggering_actor }}" >> $ENV_FILE
         if [ "${{ steps.meta.outputs.is_pr }}" == "true" ]; then
           echo "pull_request = https://github.com/${{ github.repository }}/pull/${{ github.event.number }}" >> $ENV_FILE
         fi
-        if [ "${{ github.ref_type }}" == "tag" ]; then
-          echo "tag = ${{ github.ref_name }}" >> $ENV_FILE
-        fi
       shell: bash
 
-    - name: Publish Allure report
-      id: allure
-      if: steps.check-allure.outputs.has_report == 'true' && inputs.allure-username && inputs.allure-password
-      continue-on-error: true
-      uses: LedgerHQ/send-to-allure-server-action@2.1.2
+    - name: Upload Allure results
+      if: steps.check-allure.outputs.has_allure
+      id: allure-upload
+      uses: LedgerHQ/actions/allure/upload@main
       with:
-        allure-server-url: "https://vault.allure.green.ledgerlabs.net"
-        build-name: ${{ github.workflow }}
-        build-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        username: ${{ inputs.allure-username }}
-        password: ${{ inputs.allure-password }}
-        path: ${{ steps.meta.outputs.identifier }}@${{ steps.meta.outputs.branch }}
-        allure-results: reports/allure
+        url: ${{ env.ALLURE_URL }}
+        username: ${{ env.ALLURE_USERNAME }}
+        password: ${{ env.ALLURE_PASSWORD }}
+        results: reports/allure
 
-    - name: Add Allure report link to the pull-request
-      if: steps.allure.outcome == 'success' && steps.meta.outputs.is_pr == 'true'
+    - name: Save Allure UUID
+      if: steps.allure-upload.outputs.uuid
+      run: |
+        : Save Allure UUID
+        echo $UUID > reports/allure.uuid${{ inputs.matrix-id && steps.matrix-meta.outputs.suffix || '' }}
+      env:
+        UUID: ${{ steps.allure-upload.outputs.uuid }}
+      shell: bash
+
+    - name: Store reports
+      if: inputs.matrix-id
+      uses: actions/upload-artifact@v4
+      with:
+        name: reports${{ inputs.matrix-id && format('-{0}', steps.matrix-meta.outputs.id) || '' }}
+        path: |
+          reports/coverage*
+          reports/junit*
+          reports/allure.uuid*
+
+    - name: Merge reports artifacts
+      if: inputs.report-only
+      uses: actions/upload-artifact/merge@v4
+      with:
+        name: reports
+        pattern: reports-*
+        delete-merged: true
+
+    - name: Download reports
+      if: inputs.report-only
+      uses: actions/download-artifact@v4
+      with:
+        name: reports
+        path: reports
+
+    - name: Merge reports
+      if: inputs.report-only
+      run: |
+        : Merge reports
+        echo "Install merge tooling"
+        pip install coverage[toml] junitparser
+        echo "Merge JUnit reports"
+        junitparser merge --glob reports/junit.*.xml reports/junit.xml
+        echo "Combine coverage report"
+        coverage combine --data-file reports/coverage.all reports/coverage.*.data
+        echo "Generate XML coverage report"
+        coverage xml --data-file reports/coverage.all -o reports/coverage.xml
+      shell: bash
+
+    - name: Generate Pytest coverage report
+      id: coverage
+      if: inputs.matrix-id == null
+      uses: MishaKav/pytest-coverage-comment@v1.1.52
+      with:
+        github-token: ${{ inputs.github-token }}
+        coverage-path-prefix: ${{ steps.meta.outputs.has_src == 'true' && 'src/' || '' }}
+        pytest-xml-coverage-path: ./reports/coverage.xml
+        junitxml-path: ./reports/junit.xml
+        hide-comment: true
+
+    - name: Add coverage report to summary
+      if: inputs.matrix-id == null
+      run: |
+        : Add coverage report to summary
+        echo -e ${{ steps.coverage.outputs.summaryReport }} >> summary.md
+      shell: bash
+
+    - name: Build Allure UUIDS list
+      id: allure-data
+      if: inputs.matrix-id == null
+      run: |
+        : Build Allure UUIDS list
+        echo 'uuids<<EOF' >> $GITHUB_OUTPUT
+        cat reports/allure.uuid* >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Generate Allure report
+      if: steps.allure-data.outputs.uuids && !inputs.matrix-id
+      id: allure-generate
+      uses: LedgerHQ/actions/allure/generate@main
+      with:
+        url: ${{ env.ALLURE_URL }}
+        username: ${{ env.ALLURE_USERNAME }}
+        password: ${{ env.ALLURE_PASSWORD }}
+        path: ${{ steps.meta.outputs.identifier }}@${{ steps.meta.outputs.branch }}
+        results: ${{ steps.allure-data.outputs.uuids }}
+        report-name: ${{ steps.meta.outputs.identifier }}
+
+    - name: Add Allure report link to the summary
+      if: steps.allure-generate.outcome == 'success'
+      run: |
+        : Add Allure report link to the summary
+        echo "[📊 Allure test report](${{ steps.allure-generate.outputs.url }})" >> summary.md
+      shell: bash
+
+    - name: Export summary
+      if: inputs.matrix-id == null
+      run: |
+        : Export summary
+        cat summary.md >> $GITHUB_STEP_SUMMARY
+      shell: bash
+
+    - name: Add reports to the pull-request
+      if: github.event_name == 'pull_request' && !inputs.matrix-id
       continue-on-error: true
       uses: thollander/actions-comment-pull-request@v2
       with:
-        message: "[📊 Allure test report](${{ steps.allure.outputs.report-url }})"
-        comment_tag: allure
-
-    - name: Add Allure report link to the summary
-      if: steps.allure.outcome == 'success'
-      run: echo "[📊 Allure test report](${{ steps.allure.outputs.report-url }})" >> $GITHUB_STEP_SUMMARY
-      shell: bash
+        filePath: summary.md
+        comment_tag: test-reports
 
     - name: Send coverage report to Backstage
-      if: steps.meta.outputs.has_backstage == 'true' && env.BACKSTAGE_URL && github.ref_name == 'main'
+      if: steps.meta.outputs.has_backstage == 'true' && env.BACKSTAGE_URL && github.ref_name == 'main' && !inputs.matrix-id
       continue-on-error: true  # Not critical
       run: |
+        : Send coverage report to Backstage
         # See:
         # - https://github.com/backstage/community-plugins/tree/main/workspaces/code-coverage/plugins/code-coverage-backend
         REPORT_URL="${BACKSTAGE_URL}/api/code-coverage/report?entity=component:${{ steps.meta.outputs.identifier }}"


### PR DESCRIPTION
Add support for matrix testing in `pdm/test` action.

Includes `allure/upload` and `allure/generate` supporting separate result upload and report generate for multiple results.

Due to the number of input parameters being limited to 10, all Allure parameters are now environment variables in `pdm/test` action

Fixes:
- coverage reports aggregation
- Allure reports parallel upload and aggregation
- A single report comment (instead of 1 by matrix job and for each report type)

Here's some sample runs:
- [library testing against multiple Python version](https://github.com/LedgerHQ/les-copier-demo/actions/runs/10631011298)
- [generic Python project without matrix testing](https://github.com/LedgerHQ/les-copier-demo/actions/runs/10631883510) (ensure no regressions)

> [!NOTE]
> Actions step diplay has been improved by using the solution proposed [here](https://github.com/actions/runner/issues/1877)
