### PR TITLE
fix(pdm/test): do not fail when Allure is not used

### DIFF
--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -185,7 +185,7 @@ runs:
       run: |
         : Build Allure UUIDS list
         echo 'uuids<<EOF' >> $GITHUB_OUTPUT
-        cat reports/allure.uuid* >> $GITHUB_OUTPUT
+        (cat reports/allure.uuid* >> $GITHUB_OUTPUT || true)
         echo 'EOF' >> $GITHUB_OUTPUT
       shell: bash
 


### PR DESCRIPTION
In projects not using Allure, `reports/allure.uuid*` does not exist and `cat reports/allure.uuid*` fails:

    cat: 'reports/allure.uuid*': No such file or directory

As an empty UUID list is supported in the next steps of the workflow (using `if: steps.allure-data.outputs.uuids`), ignoring the error `cat` seems to be enough to fix this issue.

Fixes: 7d2b099fe06e ("PDM: Support for matrix testing (#226)")