### PR TITLE
PDM workflows: cleaner and safer

### DIFF
--- a/pdm/doc/build/action.yml
+++ b/pdm/doc/build/action.yml
@@ -41,7 +41,9 @@ runs:
 
     - name: Update the CHANGELOG
       # Failsafe changelog too avoid failure when there is no update
-      run: pdm changelog || true
+      run: |
+        : Update the CHANGELOG
+        pdm changelog || true
       env:
         FORCE_COLOR: 'true'
       shell: bash
@@ -54,7 +56,9 @@ runs:
 
     - name: Generate the OpenAPI specifications
       if: inputs.openapi == 'true'
-      run: pdm doc:openapi
+      run: |
+        : Generate the OpenAPI specifications
+        pdm doc:openapi
       env:
         FORCE_COLOR: 'true'
       shell: bash
@@ -68,7 +72,9 @@ runs:
 
     - name: Generate the documentation
       if: inputs.site == 'true'
-      run: pdm doc:build
+      run: |
+        : Generate the documentation
+        pdm doc:build
       env:
         FORCE_COLOR: 'true'
       shell: bash
@@ -85,13 +91,16 @@ runs:
     - name: Move current OpenAPI specifications
       if: steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
       continue-on-error: true  # OpenAPI diff is optional
-      run: mv docs/openapi.yaml openapi.head.yaml
+      run: |
+        : Move current OpenAPI specifications
+        mv docs/openapi.yaml openapi.head.yaml
       shell: bash
 
     - name: Checkout base ref
       if: success() && steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
       continue-on-error: true  # OpenAPI diff is optional
       run: |
+        : Checkout base ref
         # Clean dirty state before trying to switch branch
         git restore .
         git checkout ${{ github.base_ref }}
@@ -100,13 +109,17 @@ runs:
     - name: Synchronize dependencies
       if: success() && steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
       continue-on-error: true  # OpenAPI diff is optional
-      run: pdm sync
+      run: |
+        : Synchronize dependencies
+        pdm sync
       shell: bash
 
     - name: Generate the base OpenAPI specifications
       if: success() && steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
       continue-on-error: true  # OpenAPI diff is optional
-      run: pdm doc:openapi
+      run: |
+        : Generate the base OpenAPI specifications
+        pdm doc:openapi
       env:
         FORCE_COLOR: 'true'
       shell: bash
@@ -114,7 +127,9 @@ runs:
     - name: Move base OpenAPI specifications
       if: success() && steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
       continue-on-error: true  # OpenAPI diff is optional
-      run: mv docs/openapi.yaml openapi.base.yaml
+      run: |
+        : Move base OpenAPI specifications
+        mv docs/openapi.yaml openapi.base.yaml
       shell: bash
 
     - name: Generate the OpenAPI diff

--- a/pdm/doc/publish/action.yml
+++ b/pdm/doc/publish/action.yml
@@ -53,14 +53,18 @@ runs:
 
     - name: Deploy the documentation site (main)
       if: inputs.site == 'true' && github.ref == 'refs/heads/main'
-      run: pdm doc:deploy --push --update-aliases main latest
+      run: |
+        : Deploy the documentation site \(main\)
+        pdm doc:deploy --push --update-aliases main latest
       env:
         FORCE_COLOR: 'true'
       shell: bash
 
     - name: Deploy the documentation site (tag)
       if: inputs.site == 'true' && inputs.version || startsWith(github.ref, 'refs/tags')
-      run: pdm doc:deploy --push ${{ inputs.version || github.head_ref || github.ref_name }}
+      run: |
+        : Deploy the documentation site \(tag\)
+        pdm doc:deploy --push ${{ inputs.version || github.head_ref || github.ref_name }}
       env:
         FORCE_COLOR: 'true'
       shell: bash
@@ -69,6 +73,7 @@ runs:
       id: summary
       if: inputs.site == 'true'
       run: |
+        : Publish summary
         version=${{ inputs.version || github.ref == 'refs/heads/main' && 'latest' || github.head_ref || github.ref_name }}
         url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${version}"
         echo "url=${url}" >> $GITHUB_OUTPUT

--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -60,15 +60,13 @@ runs:
     - name: Compute some variables
       id: vars
       run: |
+        : Compute some variables
         VERSION=${{ inputs.version || github.ref_type == 'tag' && github.ref_name || format('0.dev+{0}.{1}', env.DOCKER_METADATA_OUTPUT_VERSION, github.sha) }}
         echo "version=${VERSION}" >> $GITHUB_OUTPUT
         [ -f Dockerfile ] && HAS_DOCKER='true' || HAS_DOCKER='false'
         echo "has_docker=${HAS_DOCKER}" >> $GITHUB_OUTPUT
         [ -f goss.yaml ] && HAS_GOSS='true' || HAS_GOSS='false'
         echo "has_goss=${HAS_GOSS}" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: Display vars output
-      run: echo "${{ toJson(steps.vars.outputs) }}"
       shell: bash
 
     - name: Login to GitHub Container Registry
@@ -103,17 +101,22 @@ runs:
       if: steps.vars.outputs.has_goss == 'true'
 
     - name: Run GOSS validation
-      run: dgoss run ${{ inputs.dgoss-args }} ghcr.io/ledgerhq/${{ github.event.repository.name }}:${DOCKER_METADATA_OUTPUT_VERSION}
       id: goss
       if: steps.vars.outputs.has_goss == 'true'
+      run: |
+        : Run GOSS validation
+        dgoss run ${{ inputs.dgoss-args }} ghcr.io/ledgerhq/${{ github.event.repository.name }}:${DOCKER_METADATA_OUTPUT_VERSION}
       env:
         # Make dgoss works with Ledger dind runners
         GOSS_FILES_STRATEGY: cp
         CONTAINER_LOG_OUTPUT: ${{ runner.temp }}/goss.log
       shell: bash
 
-    - if: failure() && steps.vars.outputs.has_goss == 'true' && steps.goss.conclusion == 'failure'
-      run: cat ${{ runner.temp }}/goss.log
+    - name: Display GOSS failure log
+      if: failure() && steps.vars.outputs.has_goss == 'true' && steps.goss.conclusion == 'failure'
+      run: |
+        : Display GOSS failure log
+        cat ${{ runner.temp }}/goss.log
       shell: bash
 
     - name: Push docker image
@@ -140,6 +143,7 @@ runs:
       id: summary
       if: steps.vars.outputs.has_docker == 'true'
       run: |
+        : Create Summary
         IMAGE="${{ fromJSON(steps.docker.outputs.metadata)['image.name'] }}"
         IMAGE=${IMAGE##*,}
         DIGEST="${{ fromJSON(steps.docker.outputs.metadata)['containerimage.digest'] }}"

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -60,6 +60,7 @@ runs:
     - name: Bump using commitizen
       id: bump
       run: |
+        : Bump using commitizen
         CMD=('pdm' 'bump' '--changelog-to-stdout' '--git-output-to-stderr')
         if [[ $INPUT_INCREMENT ]]; then
           CMD+=('--increment' "$INPUT_INCREMENT")
@@ -77,7 +78,9 @@ runs:
     # Build once to publish the same package on every repository
     - name: Build distribution
       if: inputs.kind == 'lib'
-      run: pdm build
+      run: |
+        : Build distribution
+        pdm build
       env:
         FORCE_COLOR: 'true'
       shell: bash
@@ -90,7 +93,9 @@ runs:
         PDM_PUBLISH_USERNAME: ${{ inputs.pypi-token }}
         PDM_PUBLISH_PASSWORD: "-" # tricks github actions YAML parser and PDM test for empty password
         FORCE_COLOR: 'true'
-      run: pdm publish --no-build
+      run: |
+        : Push to GenFury
+        pdm publish --no-build
       shell: bash
 
     - name: Push to our internal Nexus
@@ -101,7 +106,9 @@ runs:
         PDM_PUBLISH_USERNAME: ${{ env.NEXUS_USER }}
         PDM_PUBLISH_PASSWORD: ${{ env.NEXUS_PASSWORD }}
         FORCE_COLOR: 'true'
-      run: pdm publish --no-build
+      run: |
+        : Push to our internal Nexus
+        pdm publish --no-build
       shell: bash
 
     - name: Push to PyPI
@@ -110,7 +117,9 @@ runs:
       env:
         PDM_PUBLISH_PASSWORD: ${{ inputs.pypi-token }}
         FORCE_COLOR: 'true'
-      run: pdm publish --no-build
+      run: |
+        : Push to PyPI
+        pdm publish --no-build
       shell: bash
 
     - name: Login to JFrog Ledger
@@ -126,7 +135,9 @@ runs:
         PDM_PUBLISH_USERNAME: ${{ steps.jfrog-login.outputs.oidc-user }}
         PDM_PUBLISH_PASSWORD: ${{ steps.jfrog-login.outputs.oidc-token }}
         FORCE_COLOR: 'true'
-      run: pdm publish --no-build
+      run: |
+        : Push to our internal JFrog Artifactory
+        pdm publish --no-build
       shell: bash
 
     - name: Docker image
@@ -140,10 +151,11 @@ runs:
         github-token: ${{ inputs.github-token }}
         dgoss-args: ${{ inputs.dgoss-args }}
 
-    - name: Add docker image to release body
+    - name: Add Docker image to release body
       if: steps.docker.outputs.image
       continue-on-error: true  # Not critical
       run: |
+        : Add Docker image to release body
         echo -e "\n**Docker image**: \`${{ steps.docker.outputs.image }}@${{ steps.docker.outputs.digest }}\`\n" >> body.md
       shell: bash
 
@@ -158,15 +170,17 @@ runs:
         site: true
         init: false
 
-    - name: Add doc to release body
+    - name: Add documentation URL to release body
       if: steps.doc.outputs.url
       continue-on-error: true  # Not critical
       run: |
+        : Add documentation URL to release body
         echo -e "\n**Documentation**: <${{ steps.doc.outputs.url }}>\n" >> body.md
       shell: bash
 
     - name: Push release commit and tag
       run: |
+        : Push release commit and tag
         git push -f
         git push -f origin ${{ env.REVISION }}
       shell: bash
@@ -187,7 +201,9 @@ runs:
 
     - name: Publish summary
       continue-on-error: true
-      run: echo "🚀 [Version ${{ env.REVISION }}](${{ steps.release.outputs.url }}) has been published" >> $GITHUB_STEP_SUMMARY
+      run: |
+        : Publish summary
+        echo "🚀 [Version ${{ env.REVISION }}](${{ steps.release.outputs.url }}) has been published" >> $GITHUB_STEP_SUMMARY
       shell: bash
 
     # Cleanup published artifacts if tag push failed
@@ -195,6 +211,7 @@ runs:
       # Runs on release failure if doc has been published
       if: always() && job.status == 'failure'
       run: |
+        : Show release failure in summary
         echo "❌ Release ${REVISION} failed" >> $GITHUB_STEP_SUMMARY
         echo "DIST=$(pdm show --name)" >> $GITHUB_ENV
       shell: bash
@@ -203,6 +220,7 @@ runs:
       # Runs on release failure if doc has been published
       if: always() && job.status == 'failure' && steps.doc.outcome == 'success'
       run: |
+        : Cleanup documentation
         pdm run mike delete --push ${REVISION}
         echo "🧹 Documentation for version ${REVISION} has been removed" >> $GITHUB_STEP_SUMMARY
       shell: bash
@@ -211,6 +229,7 @@ runs:
       # Runs on release failure if docker has been published
       if: always() && job.status == 'failure' && steps.docker.outcome == 'success'
       run: |
+        : Cleanup docker
         # See:
         #   - https://docs.github.com/en/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization
         #   - https://docs.github.com/en/rest/packages/packages#delete-package-version-for-an-organization
@@ -228,6 +247,7 @@ runs:
       # Runs on release failure if package has been published on Nexus
       if: always() && job.status == 'failure' && steps.nexus.outcome == 'success'
       run: |
+        : Cleanup Nexus
         # See:
         #   - https://help.sonatype.com/en/search-api.html#SearchAPI-SearchComponents
         #   - https://help.sonatype.com/en/components-api.html#delete-component
@@ -244,6 +264,7 @@ runs:
       # Runs on release failure if package has been published to GemFury
       if: always() && job.status == 'failure' && steps.gemfury.outcome == 'success'
       run: |
+        : Cleanup GemFury
         # See:
         #   - https://github.com/gemfury/cli/blob/main/api/yank.go
         #   - https://github.com/gemfury/cli/blob/main/api/client.go
@@ -258,6 +279,7 @@ runs:
       # Runs on release failure if package has been published to PyPI
       if: always() && job.status == 'failure' && steps.pypi.outcome == 'success'
       run: |
+        : Cleanup PyPI
         # See: https://pypi.org/help/#file-name-reuse
         echo "⚠️ You need to manually delete [\`${DIST}==${REVISION}\` on PyPI](https://pypi.org/project/${DIST}/${REVISION}/)." >> $GITHUB_STEP_SUMMARY
         echo "⚠️ The version is not usable anymore. See the [dedicated PyPI FAQ entry](https://pypi.org/help/#file-name-reuse)." >> $GITHUB_STEP_SUMMARY

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -119,20 +119,9 @@ runs:
         pdm publish --no-build
       shell: bash
 
-    - name: Push to PyPI
-      id: pypi
-      if: inputs.kind == 'lib' && inputs.public == 'true' && env.PDM_PUBLISH_PASSWORD != null
-      env:
-        PDM_PUBLISH_PASSWORD: ${{ inputs.pypi-token }}
-        FORCE_COLOR: 'true'
-      run: |
-        : Push to PyPI
-        pdm publish --no-build
-      shell: bash
-
     - name: Login to JFrog Ledger
       id: jfrog-login
-      continue-on-error: true  # Not yet mandatory
+      if: inputs.kind == 'lib' && inputs.public != 'true'
       uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
 
     - name: Push to our internal JFrog Artifactory
@@ -145,6 +134,17 @@ runs:
         FORCE_COLOR: 'true'
       run: |
         : Push to our internal JFrog Artifactory
+        pdm publish --no-build
+      shell: bash
+
+    - name: Push to PyPI
+      id: pypi
+      if: inputs.kind == 'lib' && inputs.public == 'true' && env.PDM_PUBLISH_PASSWORD != null
+      env:
+        PDM_PUBLISH_PASSWORD: ${{ inputs.pypi-token }}
+        FORCE_COLOR: 'true'
+      run: |
+        : Push to PyPI
         pdm publish --no-build
       shell: bash
 
@@ -187,6 +187,7 @@ runs:
       shell: bash
 
     - name: Push release commit and tag
+      id: tag
       run: |
         : Push release commit and tag
         git push -f
@@ -214,27 +215,26 @@ runs:
         echo "🚀 [Version ${{ env.REVISION }}](${{ steps.release.outputs.url }}) has been published" >> $GITHUB_STEP_SUMMARY
       shell: bash
 
-    ################################################################################################################
-    #                                                                                                              #
-    #                                            🧹 Cleanup actions 🧹                                             #
-    #                                                                                                              #
-    # You must ensure workflow always reach this point even in case of failure if you reach the side-effect zone ! #
-    #                                                                                                              #
-    ################################################################################################################
+    #################################################################################################
+    #                                                                                               #
+    #                                     🧹 Cleanup actions 🧹                                     #
+    #                                                                                               #
+    # You must ensure workflow always reach this point in case of failure in the side-effect zone ! #
+    #                                                                                               #
+    #################################################################################################
 
     # Cleanup published artifacts if tag push failed
     - name: Show release failure in summary
-      # Runs on release failure if doc has been published
-      if: always() && job.status == 'failure'
+      if: failure()
       run: |
         : Show release failure in summary
         echo "❌ Release ${REVISION} failed" >> $GITHUB_STEP_SUMMARY
-        echo "DIST=$(pdm show --name)" >> $GITHUB_ENV
+        echo "DIST=${{ steps.meta.outputs.identifier }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Cleanup documentation
       # Runs on release failure if doc has been published
-      if: always() && job.status == 'failure' && steps.doc.outcome == 'success'
+      if: failure() && steps.doc.outcome == 'success'
       run: |
         : Cleanup documentation
         pdm run mike delete --push ${REVISION}
@@ -243,7 +243,7 @@ runs:
 
     - name: Cleanup docker
       # Runs on release failure if docker has been published
-      if: always() && job.status == 'failure' && steps.docker.outcome == 'success'
+      if: failure() && steps.docker.outcome == 'success'
       run: |
         : Cleanup docker
         # See:
@@ -261,7 +261,7 @@ runs:
 
     - name: Cleanup Nexus
       # Runs on release failure if package has been published on Nexus
-      if: always() && job.status == 'failure' && steps.nexus.outcome == 'success'
+      if: failure() && steps.nexus.outcome == 'success'
       run: |
         : Cleanup Nexus
         # See:
@@ -278,7 +278,7 @@ runs:
 
     - name: Cleanup GemFury
       # Runs on release failure if package has been published to GemFury
-      if: always() && job.status == 'failure' && steps.gemfury.outcome == 'success'
+      if: failure() && steps.gemfury.outcome == 'success'
       run: |
         : Cleanup GemFury
         # See:
@@ -293,7 +293,7 @@ runs:
 
     - name: Cleanup PyPI
       # Runs on release failure if package has been published to PyPI
-      if: always() && job.status == 'failure' && steps.pypi.outcome == 'success'
+      if: failure() && steps.pypi.outcome == 'success'
       run: |
         : Cleanup PyPI
         # See: https://pypi.org/help/#file-name-reuse

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -169,6 +169,7 @@ runs:
 
     - name: Documentation
       id: doc
+      if: steps.meta.outputs.has_docs == 'true'
       continue-on-error: true  # Can be manually published after
       uses: LedgerHQ/actions/pdm/doc@main
       with:

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -291,6 +291,20 @@ runs:
         echo "🧹 GemFury package \`${DIST}==${REVISION}\` have been deleted" >> $GITHUB_STEP_SUMMARY
       shell: bash
 
+    - name: Cleanup JFrog Artifactory
+      # Runs on release failure if package has been published to JFrog Artifactory
+      if: failure() && steps.artifactory.outcome == 'success'
+      run: |
+        : Cleanup JFrog Artifactory
+        # See:
+        #   - https://jfrog.com/help/r/jfrog-rest-apis/introduction-to-the-jfrog-platform-rest-apis
+        #   - https://jfrog.com/help/r/jfrog-rest-apis/delete-item
+        curl -X DELETE \
+          -u ${{ steps.jfrog-login.outputs.oidc-user }}:${{ steps.jfrog-login.outputs.oidc-token }} \
+          ${{ steps.jfrog-login.outputs.jfrog-url }}/artifactory/vault-pypi-prod-green/${DIST}/${REVISION}
+        echo "🧹 JFrog Artifactory package \`${DIST}==${REVISION}\` have been deleted" >> $GITHUB_STEP_SUMMARY
+      shell: bash
+
     - name: Cleanup PyPI
       # Runs on release failure if package has been published to PyPI
       if: failure() && steps.pypi.outcome == 'success'

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -28,7 +28,9 @@ inputs:
   dgoss-args:
     description: dgoss extra docker parameters
     default: ""
-
+  artifactory-repository:
+    description: Artifactory repository to publish to
+    default: vault-pypi-prod-green
 
 
 outputs:
@@ -128,7 +130,7 @@ runs:
       id: artifactory
       if: steps.jfrog-login.outputs.oidc-user
       env:
-        PDM_PUBLISH_REPO: ${{ steps.jfrog-login.outputs.jfrog-url }}/artifactory/api/pypi/vault-pypi-prod-green
+        PDM_PUBLISH_REPO: ${{ steps.jfrog-login.outputs.jfrog-url }}/artifactory/api/pypi/${{ inputs.artifactory-repository }}
         PDM_PUBLISH_USERNAME: ${{ steps.jfrog-login.outputs.oidc-user }}
         PDM_PUBLISH_PASSWORD: ${{ steps.jfrog-login.outputs.oidc-token }}
         FORCE_COLOR: 'true'
@@ -302,8 +304,8 @@ runs:
         #   - https://jfrog.com/help/r/jfrog-rest-apis/delete-item
         curl -X DELETE \
           -u ${{ steps.jfrog-login.outputs.oidc-user }}:${{ steps.jfrog-login.outputs.oidc-token }} \
-          ${{ steps.jfrog-login.outputs.jfrog-url }}/artifactory/vault-pypi-prod-green/${DIST}/${REVISION}
-        echo "🧹 JFrog Artifactory package \`${DIST}==${REVISION}\` have been deleted" >> $GITHUB_STEP_SUMMARY
+          ${{ steps.jfrog-login.outputs.jfrog-url }}/artifactory/${{ inputs.artifactory-repository }}/${DIST}/${REVISION}
+        echo "🧹 Package \`${DIST}==${REVISION}\` have been deleted from JFrog Artifactory \`${{ inputs.artifactory-repository }}\` repository" >> $GITHUB_STEP_SUMMARY
       shell: bash
 
     - name: Cleanup PyPI

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -85,6 +85,14 @@ runs:
         FORCE_COLOR: 'true'
       shell: bash
 
+    ################################################################
+    #                                                              #
+    #                  💥 Side-effect zone 💥                      #
+    #                                                              #
+    # Successful actions will need cleanup 🧹 in case of failure ! #
+    #                                                              #
+    ################################################################
+
     - name: Push to GemFury
       id: gemfury
       if: inputs.kind == 'lib' && inputs.public != 'true' && env.PDM_PUBLISH_USERNAME != null
@@ -205,6 +213,14 @@ runs:
         : Publish summary
         echo "🚀 [Version ${{ env.REVISION }}](${{ steps.release.outputs.url }}) has been published" >> $GITHUB_STEP_SUMMARY
       shell: bash
+
+    ################################################################################################################
+    #                                                                                                              #
+    #                                            🧹 Cleanup actions 🧹                                             #
+    #                                                                                                              #
+    # You must ensure workflow always reach this point even in case of failure if you reach the side-effect zone ! #
+    #                                                                                                              #
+    ################################################################################################################
 
     # Cleanup published artifacts if tag push failed
     - name: Show release failure in summary

--- a/pdm/release/pre/action.yml
+++ b/pdm/release/pre/action.yml
@@ -21,7 +21,7 @@ runs:
       if: failure()
       run: |
         : Notify failure
-        echo "${MESSAGE}" >> $GITHUB_SUMMARY
+        echo "${MESSAGE}" >> $GITHUB_STEP_SUMMARY
         echo "${MESSAGE}"
       env:
         MESSAGE: |

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -179,26 +179,28 @@ runs:
         echo -e ${{ steps.coverage.outputs.summaryReport }} >> summary.md
       shell: bash
 
-    - name: Build Allure UUIDS list
-      id: allure-data
+    - name: Prepare Allure report metadata
+      id: allure-report-meta
       if: inputs.matrix-id == null
       run: |
-        : Build Allure UUIDS list
+        : Prepare Allure report metadata
         echo 'uuids<<EOF' >> $GITHUB_OUTPUT
         (cat reports/allure.uuid* >> $GITHUB_OUTPUT || true)
         echo 'EOF' >> $GITHUB_OUTPUT
+        [ "${{ steps.meta.outputs.branch }}" == "main" ] && suffix="" || suffix="@${{ steps.meta.outputs.branch }}"
+        echo "suffix=${suffix}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Generate Allure report
-      if: steps.allure-data.outputs.uuids && !inputs.matrix-id
+      if: steps.allure-report-meta.outputs.uuids && !inputs.matrix-id
       id: allure-generate
       uses: LedgerHQ/actions/allure/generate@main
       with:
         url: ${{ env.ALLURE_URL }}
         username: ${{ env.ALLURE_USERNAME }}
         password: ${{ env.ALLURE_PASSWORD }}
-        path: ${{ steps.meta.outputs.identifier }}@${{ steps.meta.outputs.branch }}
-        results: ${{ steps.allure-data.outputs.uuids }}
+        path: ${{ steps.meta.outputs.identifier }}${{ steps.allure-report-meta.outputs.suffix }}
+        results: ${{ steps.allure-report-meta.outputs.uuids }}
         report-name: ${{ steps.meta.outputs.identifier }}
 
     - name: Add Allure report link to the summary


### PR DESCRIPTION
## Cleaner

- always display proper name on `bash` steps (help to understand what happened and where it has failed exactly)
- remove the `@main` suffix on `main` branch Allure report (easier to distinguish from branch report, less cluttered listing). Supersedes #235 

## Safer

- Ensure release always reach cleanup in case of failure so we don't let half-baked releases needing to manually clean
- Bail off all steps after failure when possible
- Add JFrog Artifactory cleanup in case of failure
- JFrog Artifactory repository is now an input parameter
- Do not fail on missing documentation

## Sample runs
- successful release: https://github.com/LedgerHQ/les-copier-demo/actions/runs/10745129557
- cleanup on tag failure: https://github.com/LedgerHQ/les-copier-demo/actions/runs/10744133372
- cleanup Nexus on JFrog failure: https://github.com/LedgerHQ/les-copier-demo/actions/runs/10743637884
- conditions not met: https://github.com/LedgerHQ/les-copier-demo/actions/runs/10743502973
- documentation is failsafe: https://github.com/LedgerHQ/les-copier-demo/actions/runs/10742997702

Unable to safely test GemFury cleanup as there are no more seats available.

> [!NOTE]
> Actions steps display has been improved using the solution proposed [here](https://github.com/actions/runner/issues/1877)

> [!WARNING]
> Do not merge yet, needs to be tested before