### PR TITLE
feat(pdm/release): package the pre-conditions checks as a reusable action `pdm/release/pre`

### DIFF
--- a/pdm/release/pre/README.md
+++ b/pdm/release/pre/README.md
@@ -1,0 +1,27 @@
+# Check release pre-conditions
+
+Check that all requirements for a release are met
+
+## Usage
+
+```yaml
+jobs:
+  pre:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LedgerHQ/actions/pdm/release/pre@main
+        with:
+          workflow: check.yml
+          github-token: ${{ github.token }}
+```
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `workflow` | Required workflow file | `ci.yml` | `false` |
+| `github-token` | A Github token with proper permissions | `""` | `true` |
+
+## Outputs
+
+N/A

--- a/pdm/release/pre/action.yml
+++ b/pdm/release/pre/action.yml
@@ -1,0 +1,30 @@
+name: Check release pre-conditions
+description: Check that all requirements for a release are met
+
+inputs:
+  workflow:
+    description: Required workflow file
+    default: ci.yml
+  github-token:
+    description: A Github token with proper permissions
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Ensure CI success
+      uses: noirbizarre/need-checks@0.1
+      with:
+        workflow: ${{ inputs.workflow }}
+        token: ${{ inputs.github-token }}
+    - name: Notify failure
+      if: failure()
+      run: |
+        : Notify failure
+        echo "${MESSAGE}" >> $GITHUB_SUMMARY
+        echo "${MESSAGE}"
+      env:
+        MESSAGE: |
+          👮 Pre-conditions check has failed ❌
+          ⚠️ You can only release a commit where all checks from `${{ inputs.workflow }}` workflow are green 🟢
+      shell: bash


### PR DESCRIPTION
Extract the `Pre-conditions check` workflow from `python.copier` as a reusable action.

Also added a clear message to explain that CI need to be green 🟢 to run a release.