### PR TITLE
fix(pdm): comment using the provided PAT

### DIFF
--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -226,6 +226,7 @@ runs:
       with:
         filePath: summary.md
         comment_tag: test-reports
+        GITHUB_TOKEN: ${{ inputs.github-token }}
 
     - name: Send coverage report to Backstage
       if: steps.meta.outputs.has_backstage == 'true' && env.BACKSTAGE_URL && github.ref_name == 'main' && !inputs.matrix-id


### PR DESCRIPTION
Comment using the provided (and required) PAT to avoid the need for extra permissions on the callers (workflows using this action)