### PR TITLE
fix(pdm/release): fix documentation of input `github-token`

### DIFF
--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: ""
   github-token:
-    description: A Github token with
+    description: A Github token with proper permissions
     required: true
   increment:
     description: "Kind of increment (optional: `MAJOR|MINOR|PATCH`)"


### PR DESCRIPTION
It was truncated.