### PR TITLE
feat(jfrog): adds opt-in Jfrog Artifactory support on `python-app` (VG-21684)

### DIFF
--- a/python-app/README.md
+++ b/python-app/README.md
@@ -51,3 +51,7 @@ This step is only active if `redocly-project` is given.
 
 For convenience, we also provide `LedgerHQ/actions/python-app/init` that setup
 python and run `pipenv sync` (with `--dev` optionally)
+
+JFrog Artifactory support is automatically enabled with:
+- `JFROG_REPOSITORY` environment variable for PyPI repository as source
+- `JFROG_DOCKER_REPOSITORY` environment variable for Docker/OCI image publication

--- a/python-app/docker/action.yml
+++ b/python-app/docker/action.yml
@@ -37,9 +37,21 @@ runs:
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Info for build
       run: |
-        # lowercase image name
-        echo IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
         echo VERSION=$(git describe --tags) >> $GITHUB_ENV
+        echo "IMAGES<<EOF" >> $GITHUB_ENV
+        if [ -n "${JFROG_DOCKER_REPOSITORY}" ]; then
+          JFROG_IMAGE=${JFROG_DOMAIN}/${JFROG_DOCKER_REPOSITORY}/${{ github.event.repository.name }}
+          echo "${JFROG_IMAGE}" >> $GITHUB_ENV
+        fi
+        GHCR_IMAGE=ghcr.io/ledgerhq/${{ github.event.repository.name }}
+        echo "${GHCR_IMAGE}" >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+        # Keep only one image as canonical reference
+        if [ -n "${JFROG_IMAGE}" ]; then
+          echo "IMAGE=${JFROG_IMAGE}" >> $GITHUB_ENV
+        else
+          echo "IMAGE=${GHCR_IMAGE}" >> $GITHUB_ENV
+        fi
       shell: bash
 
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
@@ -60,7 +72,7 @@ runs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.IMAGE }}
+        images: ${{ env.IMAGES }}
         flavor: |
             latest=false
         tags: |
@@ -80,6 +92,28 @@ runs:
       with:
         platforms: ${{ inputs.platforms }}
 
+    - name: Authenticate against JFrog Artifactory
+      id: jfrog-login
+      if: steps.check-docker.outputs.is-docker-needed == 'true' && env.JFROG_REPOSITORY || env.JFROG_DOCKER_REPOSITORY
+      uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
+
+    - name: Login to JFrog Artifactory internal registry
+      if: steps.check-docker.outputs.is-docker-needed == 'true' && env.JFROG_DOCKER_REPOSITORY
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.JFROG_DOMAIN }}/${{ env.JFROG_DOCKER_REPOSITORY }}
+        username: ${{ env.JFROG_USER }}
+        password: ${{ env.JFROG_TOKEN }}
+
+    # Needed for Pipenv only, so has to be done after Docker Authentication
+    - name: URL Encode credentials
+      if: steps.jfrog-login.outcome == 'success'
+      run: |
+        : URL Encode credentials
+        echo "JFROG_USER=$(echo $JFROG_USER | jq -Rr '@uri')" >> $GITHUB_ENV
+        echo "JFROG_TOKEN=$(echo $JFROG_TOKEN | jq -Rr '@uri')" >> $GITHUB_ENV
+      shell: bash
+
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Build and push
       id: docker_build
@@ -90,10 +124,27 @@ runs:
         # `Dockerfile` can mount and use the secret at: /run/secrets/PYPI_DEPLOY_TOKEN
         secrets: |
           PYPI_DEPLOY_TOKEN=${{ env.PYPI_DEPLOY_TOKEN }}
+          JFROG_USER=${{ env.JFROG_USER }}
+          JFROG_TOKEN=${{ env.JFROG_TOKEN }}
         build-args: |
           ${{ inputs.build-args }}
           PYPI_DEPLOY_TOKEN=${{ env.PYPI_DEPLOY_TOKEN }}
+          JFROG_REPOSITORY=${{ env.JFROG_REPOSITORY }}
           VERSION=${{ env.VERSION }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         push: true
+
+    - name: Attest Docker image for JFrog Artifactory
+      if: steps.check-docker.outputs.is-docker-needed == 'true' && env.JFROG_DOCKER_REPOSITORY
+      uses: LedgerHQ/actions-security/actions/attest@actions/attest-1
+      with:
+        subject-name: ${{ env.IMAGE }}
+        subject-digest: ${{ steps.docker_build.outputs.digest }}
+
+    - name: Sign Docker image for JFrog Artifactory
+      if: steps.check-docker.outputs.is-docker-needed == 'true' && env.JFROG_DOCKER_REPOSITORY
+      uses: LedgerHQ/actions-security/actions/sign-container@actions/sign-container-1
+      with:
+        tags: ${{ steps.meta.outputs.tags }}
+        digest: ${{ steps.docker_build.outputs.digest }}

--- a/python-app/goss/action.yml
+++ b/python-app/goss/action.yml
@@ -31,6 +31,27 @@ runs:
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    - name: Authenticate against JFrog Artifactory
+      id: jfrog-login
+      if: steps.goss_file.outputs.goss_enabled == 'true' && env.JFROG_REPOSITORY || env.JFROG_DOCKER_REPOSITORY
+      uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
+
+    - name: Login to JFrog Artifactory internal registry
+      if: steps.goss_file.outputs.goss_enabled == 'true' && env.JFROG_DOCKER_REPOSITORY
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.JFROG_DOMAIN }}/${{ env.JFROG_DOCKER_REPOSITORY }}
+        username: ${{ env.JFROG_USER }}
+        password: ${{ env.JFROG_TOKEN }}
+
+    # Needed for Pipenv only, so has to be done after Docker Authentication
+    - name: URL Encode credentials
+      if: steps.jfrog-login.outcome == 'success'
+      run: |
+        : URL Encode credentials
+        echo "JFROG_USER=$(echo $JFROG_USER | jq -Rr '@uri')" >> $GITHUB_ENV
+        echo "JFROG_TOKEN=$(echo $JFROG_TOKEN | jq -Rr '@uri')" >> $GITHUB_ENV
+      shell: bash
 
     - if: ${{ steps.goss_file.outputs.goss_enabled == 'true' }}
       name: Build docker image
@@ -43,7 +64,10 @@ runs:
         # `Dockerfile` can mount and use the secret at: /run/secrets/PYPI_DEPLOY_TOKEN
         secrets: |
           PYPI_DEPLOY_TOKEN=${{ env.PYPI_DEPLOY_TOKEN }}
+          JFROG_USER=${{ env.JFROG_USER }}
+          JFROG_TOKEN=${{ env.JFROG_TOKEN }}
         build-args: |
+          JFROG_REPOSITORY=${{ env.JFROG_REPOSITORY }}
           PYPI_DEPLOY_TOKEN=${{ env.PYPI_DEPLOY_TOKEN }}
 
     - if: ${{ steps.goss_file.outputs.goss_enabled == 'true' }}
@@ -56,6 +80,7 @@ runs:
       run: dgoss run --network "host" ${{ inputs.GOSS_IMAGE }}
       env:
         GOSS_FILES_PATH: ${{ inputs.GOSS_FILES_PATH }}
+        GOSS_FILES_STRATEGY: cp
         CONTAINER_LOG_OUTPUT: ${{ runner.temp }}/goss.log
       shell: bash
 

--- a/python-app/init/action.yml
+++ b/python-app/init/action.yml
@@ -30,25 +30,28 @@ runs:
         python-version: ${{ steps.parse-python-version.outputs.python-version }}
         cache: 'pipenv'
 
+    - name: Authenticate against JFrog Artifactory
+      id: jfrog-login
+      if: env.JFROG_REPOSITORY
+      uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
+
+    - name: URL Encode credentials
+      if: steps.jfrog-login.outcome == 'success'
+      run: |
+        : URL Encode credentials
+        echo "JFROG_USER=$(echo $JFROG_USER | jq -Rr '@uri')" >> $GITHUB_ENV
+        echo "JFROG_TOKEN=$(echo $JFROG_TOKEN | jq -Rr '@uri')" >> $GITHUB_ENV
+      shell: bash
+
     - name: Install pipenv
       run: |
-        pip install --upgrade pip
-        pip install pipenv
+        pip install --upgrade pip pipenv wheel
         python --version ; pip --version ; pipenv --version
       shell: bash
 
-    - if: ${{ inputs.sync-dev == 'true' }}
-      name: Install package in dev mode
+    - name: Install packages
       run: |
-        pipenv sync --dev
-      env:
-        PYPI_DEPLOY_TOKEN: ${{ env.PYPI_DEPLOY_TOKEN }}
-      shell: bash
-
-    - if: ${{ inputs.sync-dev == 'false' }}
-      name: Install package in normal mode
-      run: |
-        pipenv sync
+        pipenv sync ${{ inputs.sync-dev == 'true' && '--dev' || '' }}
       env:
         PYPI_DEPLOY_TOKEN: ${{ env.PYPI_DEPLOY_TOKEN }}
       shell: bash

--- a/python-app/openapi-diff/action.yaml
+++ b/python-app/openapi-diff/action.yaml
@@ -18,6 +18,19 @@ runs:
   using: "composite"
 
   steps:
+    - name: Authenticate against JFrog Artifactory
+      id: jfrog-login
+      if: env.JFROG_REPOSITORY
+      uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
+
+    - name: URL Encode credentials
+      if: steps.jfrog-login.outcome == 'success'
+      run: |
+        : URL Encode credentials
+        echo "JFROG_USER=$(echo $JFROG_USER | jq -Rr '@uri')" >> $GITHUB_ENV
+        echo "JFROG_TOKEN=$(echo $JFROG_TOKEN | jq -Rr '@uri')" >> $GITHUB_ENV
+      shell: bash
+
     - name: set up python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
Opt-in support for JFrog Artifactory on `python-app` (consume libs from, publish images to, attest and sign images).

Triggered by `JFROG_REPOSITORY` and `JFROG_DOCKER_REPOSITORY` environment variable.

VG-21684

## Sample runs

### With JFrog Artifactory support
- https://github.com/LedgerHQ/vault-api-gateway/actions/runs/11347483550/job/31562035776?pr=689
- https://github.com/LedgerHQ/vault-api-gateway/actions/runs/11347483535/job/31558973191?pr=689

### Without JFrog Artifactory support (Backward compatibility)
- https://github.com/LedgerHQ/vault-api-gateway/actions/runs/11346063232/job/31554299863?pr=690
- https://github.com/LedgerHQ/vault-api-gateway/actions/runs/11346063216/job/31554299855?pr=690