### PR TITLE
fix(pdm/test): update `actions-comment-pull-request` parameters to v3 naming

### DIFF
--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -224,9 +224,9 @@ runs:
       continue-on-error: true
       uses: thollander/actions-comment-pull-request@v3
       with:
-        filePath: summary.md
-        comment_tag: test-reports
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        file-path: summary.md
+        comment-tag: test-reports
+        github-token: ${{ inputs.github-token }}
 
     - name: Send coverage report to Backstage
       if: steps.meta.outputs.has_backstage == 'true' && env.BACKSTAGE_URL && github.ref_name == 'main' && !inputs.matrix-id


### PR DESCRIPTION
#249 had breaking change on parameter names.

This PR applies the updated naming