### PR TITLE
Early Docker Hub authentication if possible to avoid rate limiting

### DIFF
--- a/pdm/docker/README.md
+++ b/pdm/docker/README.md
@@ -54,6 +54,8 @@ jobs:
 |--------|-------------|
 | `JFROG_REPOSITORY` | JFrog repository used to fetch internal dependencies (triggers authentication) |
 | `JFROG_DOCKER_REPOSITORY` | JFrog repository to publish images to (triggers authentication and publication) |
+| `DOCKERHUB_USERNAME` | Optional Docker Hub username (in case you depend on it and to avoir rate limiting) |
+| `DOCKERHUB_PASSWORD` | Optional Docker Hub password (in case you depend on it and to avoir rate limiting) |
 
 ## Outputs
 

--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -37,15 +37,40 @@ runs:
     - name: Clone
       if: inputs.clone == 'true'
       uses: actions/checkout@v4
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+
+    # Authenticate early to avoid rate limiting while pulling images in nested actions
+
+    - name: Login to Docker Hub
+      if: env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD
+      uses: docker/login-action@v3
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github-token }}
 
     - name: Authenticate against JFrog Artifactory
       id: jfrog-login
       if: env.JFROG_REPOSITORY || env.JFROG_DOCKER_REPOSITORY
       uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
+
+    - name: Login to JFrog Artifactory internal registry
+      if: env.JFROG_TOKEN
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.JFROG_DOMAIN }}/${{ env.JFROG_DOCKER_REPOSITORY }}
+        username: ${{ env.JFROG_USER }}
+        password: ${{ env.JFROG_TOKEN }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Compute some variables
       id: vars
@@ -87,22 +112,6 @@ runs:
           type=ref,event=pr
           type=pep440,pattern={{major}}
           type=pep440,pattern={{major}}.{{minor}}
-
-    - name: Login to GitHub Container Registry
-      if: steps.vars.outputs.has_docker == 'true'
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ inputs.github-token }}
-
-    - name: Login to JFrog Artifactory internal registry
-      if: env.JFROG_DOCKER_REPOSITORY
-      uses: docker/login-action@v3
-      with:
-        registry: ${{ env.JFROG_DOMAIN }}/${{ env.JFROG_DOCKER_REPOSITORY }}
-        username: ${{ env.JFROG_USER }}
-        password: ${{ env.JFROG_TOKEN }}
 
     - name: Build docker image
       if: steps.vars.outputs.has_goss == 'true'

--- a/python-app/README.md
+++ b/python-app/README.md
@@ -26,6 +26,8 @@ jobs:
           CI_BOT_USERNAME: ${{ secrets.CI_BOT_USERNAME }}
           CI_BOT_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
           REDOCLY_AUTHORIZATION: ${{ secrets.REDOCLY_AUTHORIZATION }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 ```
 
 This action is a `composite` of

--- a/python-app/docker/action.yml
+++ b/python-app/docker/action.yml
@@ -34,6 +34,14 @@ runs:
       with:
         fetch-depth: 0 # needed for VERSION
 
+    # Authenticate against Docker Hub early to avoid rate-limiting on steps pulling images
+    - name: Login to Docker Hub
+      if: steps.check-docker.outputs.is-docker-needed == 'true' && env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD
+      uses: docker/login-action@v3
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}
+
     - if: ${{ steps.check-docker.outputs.is-docker-needed == 'true' }}
       name: Info for build
       run: |


### PR DESCRIPTION
Try to authenticate early on Docker Hub when possible (ie. credentials available) to avoid rate limiting while pulling images.