### PR TITLE
feat(pdm): supports repository with an extra docker image

### DIFF
--- a/pdm/docker/README.md
+++ b/pdm/docker/README.md
@@ -47,6 +47,8 @@ jobs:
 | `build-args` | Docker build command extra `build-args` (multiline supported) | `""` | `false` |
 | `secrets` | Docker build command extra `secrets` (multiline supported) | `""` | `false` |
 | `dgoss-args` | dgoss extra docker parameters | `""` | `false` |
+| `name` | Optional image name (default to repository name) | `""` | `false` |
+| `suffix` | Optional Dockerfile suffix | `""` | `false` |
 
 ## Environment variables
 

--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -21,6 +21,12 @@ inputs:
   dgoss-args:
     description: dgoss extra docker parameters
     default: ""
+  name:
+    description: Optional image name (default to repository name)
+    default: ""
+  suffix:
+    description: Optional Dockerfile suffix
+    default: ""
 
 
 outputs:
@@ -76,18 +82,26 @@ runs:
       id: vars
       run: |
         : Compute some variables
+        NAME=${{ inputs.name || github.event.repository.name }}
         VERSION=${{ inputs.version || github.ref_type == 'tag' && github.ref_name || format('0.dev+{0}.{1}', env.DOCKER_METADATA_OUTPUT_VERSION, github.sha) }}
+        DOCKERFILE=${{ inputs.suffix && format('Dockerfile.{0}', inputs.suffix) || 'Dockerfile' }}
+        GOSSPATH=${{ inputs.suffix || '.' }}
+
+        echo "name=${NAME}" >> $GITHUB_OUTPUT
         echo "version=${VERSION}" >> $GITHUB_OUTPUT
-        [ -f Dockerfile ] && HAS_DOCKER='true' || HAS_DOCKER='false'
+        echo "dockerfile=${DOCKERFILE}" >> $GITHUB_OUTPUT
+        echo "gosspath=${GOSSPATH}" >> $GITHUB_OUTPUT
+
+        [ -f ${DOCKERFILE} ] && HAS_DOCKER='true' || HAS_DOCKER='false'
         echo "has_docker=${HAS_DOCKER}" >> $GITHUB_OUTPUT
-        [ -f goss.yaml ] && HAS_GOSS='true' || HAS_GOSS='false'
+        [ -f ${GOSSPATH}/goss.yaml ] && HAS_GOSS='true' || HAS_GOSS='false'
         echo "has_goss=${HAS_GOSS}" >> $GITHUB_OUTPUT
         echo "images<<EOF" >> $GITHUB_OUTPUT
         if [ -n "${JFROG_DOCKER_REPOSITORY}" ]; then
-          JFROG_IMAGE=${JFROG_DOMAIN}/${JFROG_DOCKER_REPOSITORY}/${{ github.event.repository.name }}
+          JFROG_IMAGE=${JFROG_DOMAIN}/${JFROG_DOCKER_REPOSITORY}/${NAME}
           echo "${JFROG_IMAGE}" >> $GITHUB_OUTPUT
         fi
-        GHCR_IMAGE=ghcr.io/ledgerhq/${{ github.event.repository.name }}
+        GHCR_IMAGE=ghcr.io/ledgerhq/${NAME}
         echo "${GHCR_IMAGE}" >> $GITHUB_OUTPUT
         echo 'EOF' >> $GITHUB_OUTPUT
         # Keep only one image as canonical reference
@@ -112,11 +126,14 @@ runs:
           type=ref,event=pr
           type=pep440,pattern={{major}}
           type=pep440,pattern={{major}}.{{minor}}
+        labels: |
+          org.opencontainers.image.title=${{ steps.vars.outputs.name }}
 
     - name: Build docker image
       if: steps.vars.outputs.has_goss == 'true'
       uses: docker/build-push-action@v6
       with:
+        file: ${{ steps.vars.outputs.dockerfile }}
         build-args: |
           VERSION=${{ steps.vars.outputs.version }}
           DD_GIT_REPOSITORY_URL=github.com/${{ github.repository }}
@@ -132,6 +149,7 @@ runs:
         load: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
@@ -148,6 +166,7 @@ runs:
         : Run GOSS validation
         dgoss run ${{ inputs.dgoss-args }} ${{ steps.vars.outputs.image }}:${DOCKER_METADATA_OUTPUT_VERSION}
       env:
+        GOSS_FILES_PATH: ${{ steps.vars.outputs.gosspath }}
         # Make dgoss works with Ledger dind runners
         GOSS_FILES_STRATEGY: cp
         CONTAINER_LOG_OUTPUT: ${{ runner.temp }}/goss.log
@@ -165,6 +184,7 @@ runs:
       id: docker
       if: steps.vars.outputs.has_docker == 'true'
       with:
+        file: ${{ steps.vars.outputs.dockerfile }}
         build-args: |
           VERSION=${{ steps.vars.outputs.version }}
           DD_GIT_REPOSITORY_URL=github.com/${{ github.repository }}
@@ -180,6 +200,7 @@ runs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 

--- a/pdm/release/README.md
+++ b/pdm/release/README.md
@@ -50,13 +50,14 @@ jobs:
 |-------|-------------|---------|----------|
 | `kind` | Kind of project to release (lib/app) | `app` | `true` |
 | `pypi-token` | A Token to publish on PyPI (private or public) | `""` | `false` |
-| `github-token` | A Github token with | `""` | `true` |
+| `github-token` | A Github token with proper permissions | `""` | `true` |
 | `increment` | Kind of increment (optional: `MAJOR\|MINOR\|PATCH`) | `""` | `false` |
 | `group` | Dependency group(s) to install | `docs` | `false` |
 | `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
 | `public` | Is it a public library ? | `false` | `false` |
 | `dgoss-args` | `dgoss` extra docker parameters | `""` | `false` |
 | `artifactory-repository` | Artifactory repository to publish to (deprecated for `JFROG_REPOSITORY`) | `""` | `false` |
+| `extra-docker` | An optional extra docker image to build | `""` | `false` |
 
 ## Environment variables
 

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -40,6 +40,9 @@ inputs:
   artifactory-repository:
     description: Artifactory repository to publish to (deprecated for `JFROG_REPOSITORY`)
     default: ""
+  extra-docker:
+    description: An optional extra docker image to build
+    default: ""
 
 
 outputs:
@@ -187,6 +190,26 @@ runs:
         echo -e "\n**Docker image**: \`${{ steps.docker.outputs.image }}@${{ steps.docker.outputs.digest }}\`\n" >> body.md
       shell: bash
 
+    - name: Extra Docker image
+      uses: LedgerHQ/actions/pdm/docker@main
+      id: extra-docker
+      if: inputs.kind == 'app' && inputs.extra-docker
+      with:
+        clone: false
+        version: ${{ env.REVISION }}
+        pypi-token: ${{ inputs.pypi-token }}
+        github-token: ${{ inputs.github-token }}
+        name: ${{ inputs.extra-docker }}
+        suffix: ${{ inputs.extra-docker }}
+
+    - name: Add Extra Docker image to release body
+      if: steps.extra-docker.outputs.image
+      continue-on-error: true  # Not critical
+      run: |
+        : Add extra Docker image to release body
+        echo -e "\n**Additional Docker image**: \`${{ steps.extra-docker.outputs.image }}@${{ steps.extra-docker.outputs.digest }}\`\n" >> body.md
+      shell: bash
+
     - name: Documentation
       id: doc
       if: steps.meta.outputs.has_docs == 'true'
@@ -266,7 +289,7 @@ runs:
       # Runs on release failure if docker has been published
       if: failure() && steps.docker.outcome == 'success'
       run: |
-        : Cleanup docker
+        : Cleanup docker GHCR image
         # See:
         #   - https://docs.github.com/en/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization
         #   - https://docs.github.com/en/rest/packages/packages#delete-package-version-for-an-organization
@@ -276,7 +299,7 @@ runs:
         QUERY='.[] | select(.name == "${{ steps.docker.outputs.digest }}") | .id'
         VERSION_ID=$(echo ${VERSIONS} | jq --raw-output ${QUERY})
         ${GHAPI[@]} --method DELETE /orgs/LedgerHQ/packages/container/${PKG}/versions/${VERSION_ID}
-        IMAGE='${{ steps.docker.outputs.image }}@${{ steps.docker.outputs.digest }}'
+        IMAGE="ghcr.io/${{ github.repository }}:${REVISION}@${{ steps.docker.outputs.digest }}"
         echo "🧹 Docker image \`${IMAGE}\` has been deleted" | tee -a $GITHUB_STEP_SUMMARY
       shell: bash
 
@@ -289,8 +312,39 @@ runs:
         #   - https://jfrog.com/help/r/jfrog-rest-apis/introduction-to-the-jfrog-platform-rest-apis
         #   - https://jfrog.com/help/r/jfrog-rest-apis/delete-item
         curl -X DELETE -u ${JFROG_USER}:${JFROG_TOKEN} ${JFROG_URL}/artifactory/${JFROG_DOCKER_REPOSITORY}/${DIST}/${REVISION}
+        IMAGE="${JFROG_DOMAIN}/${JFROG_DOCKER_REPOSITORY}/${DIST}:${REVISION}@${{ steps.docker.outputs.digest }}"
         echo "🧹 Docker image \`${IMAGE}\` has been deleted" | tee -a $GITHUB_STEP_SUMMARY
-        echo "🧹 Package \`${DIST}==${REVISION}\` have been deleted from JFrog Artifactory \`${JFROG_DOCKER_REPOSITORY}\` repository" | tee -a $GITHUB_STEP_SUMMARY
+      shell: bash
+
+    - name: Cleanup extra docker GHCR image
+      # Runs on release failure if extra docker image has been published
+      if: failure() && steps.extra-docker.outcome == 'success'
+      run: |
+        : Cleanup extra docker GHCR image
+        # See:
+        #   - https://docs.github.com/en/rest/packages/packages#list-package-versions-for-a-package-owned-by-an-organization
+        #   - https://docs.github.com/en/rest/packages/packages#delete-package-version-for-an-organization
+        GHAPI=("gh" "api" "-H" "Accept: application/vnd.github+json" "-H" "X-GitHub-Api-Version: 2022-11-28")
+        PKG='${{ inputs.extra-docker }}'
+        VERSIONS=$(${GHAPI[@]} /orgs/LedgerHQ/packages/container/${PKG}/versions)
+        QUERY='.[] | select(.name == "${{ steps.extra-docker.outputs.digest }}") | .id'
+        VERSION_ID=$(echo ${VERSIONS} | jq --raw-output ${QUERY})
+        ${GHAPI[@]} --method DELETE /orgs/LedgerHQ/packages/container/${PKG}/versions/${VERSION_ID}
+        IMAGE="ghcr.io/${{ github.repository_owner }}/${{ inputs.extra-docker }}:${REVISION}@${{ steps.extra-docker.outputs.digest }}"
+        echo "🧹 Docker image \`${IMAGE}\` has been deleted" | tee -a $GITHUB_STEP_SUMMARY
+      shell: bash
+
+    - name: Cleanup extra docker JFrog Artifactory image
+      # Runs on release failure if docker has been published
+      if: failure() && steps.extra-docker.outcome == 'success' && env.JFROG_DOCKER_REPOSITORY
+      run: |
+        : Cleanup extra docker JFrog Artifactory image
+        # See:
+        #   - https://jfrog.com/help/r/jfrog-rest-apis/introduction-to-the-jfrog-platform-rest-apis
+        #   - https://jfrog.com/help/r/jfrog-rest-apis/delete-item
+        curl -X DELETE -u ${JFROG_USER}:${JFROG_TOKEN} ${JFROG_URL}/artifactory/${JFROG_DOCKER_REPOSITORY}/${{ inputs.extra-docker }}/${REVISION}
+        IMAGE="${JFROG_DOMAIN}/${JFROG_DOCKER_REPOSITORY}/${{ inputs.extra-docker }}:${REVISION}@${{ steps.docker.outputs.digest }}"
+        echo "🧹 Docker image \`${IMAGE}\` has been deleted" | tee -a $GITHUB_STEP_SUMMARY
       shell: bash
 
     - name: Cleanup GemFury


### PR DESCRIPTION
This PR allows repositories to publish an extra docker image.

In this case, it needs to follow this convention:
- a `Dockerfile.<name>` file
- optionally, a `<name>` directory containing `goss.yaml` and `goss_wait.yaml` if supported
- CI workflow will have an extra docker job with `name` and `suffix` parameter set to `name`
- Release workflow will have the `extra_docker` parameter set to `<name>`

Published images will be:
- `ghcr.io/ledgerhq/<name>:<version>`
- `jfrog.ledgerlabs.net/<jfrog repo>/<name>:<version>`

Where `<version>` is in sync with nominal image.

The resulting image will have proper labels and annotations (annotations support have been added in this PR)

Resulting workflows:
- CI: https://github.com/LedgerHQ/les-copier-demo/actions/runs/11918640466
- Release: https://github.com/LedgerHQ/les-copier-demo/actions/runs/11921131995

Non regression (CI/docker action being called and tested in the new workflow):
- Release: https://github.com/LedgerHQ/les-copier-demo/actions/runs/11914238320