### PR TITLE
feat(pdm): allows to override the generated docker image name release

### DIFF
--- a/pdm/release/README.md
+++ b/pdm/release/README.md
@@ -57,6 +57,7 @@ jobs:
 | `public` | Is it a public library ? | `false` | `false` |
 | `dgoss-args` | `dgoss` extra docker parameters | `""` | `false` |
 | `artifactory-repository` | Artifactory repository to publish to (deprecated for `JFROG_REPOSITORY`) | `""` | `false` |
+| `docker-name` | Optionally override the docker image name (default to the repository name) | `""` | `false` |
 | `extra-docker` | An optional extra docker image to build | `""` | `false` |
 
 ## Environment variables

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -40,6 +40,9 @@ inputs:
   artifactory-repository:
     description: Artifactory repository to publish to (deprecated for `JFROG_REPOSITORY`)
     default: ""
+  docker-name:
+    description: Optionally override the docker image name (default to the repository name)
+    default: ""
   extra-docker:
     description: An optional extra docker image to build
     default: ""
@@ -181,6 +184,7 @@ runs:
         pypi-token: ${{ inputs.pypi-token }}
         github-token: ${{ inputs.github-token }}
         dgoss-args: ${{ inputs.dgoss-args }}
+        name: ${{ inputs.docker-name }}
 
     - name: Add Docker image to release body
       if: steps.docker.outputs.image


### PR DESCRIPTION
Allows to optionally override the docker image name in `pdm/release`