### PR TITLE
feat(pdm): detect libraries and JFrog support to avoid failures

### DIFF
--- a/pdm/init/README.md
+++ b/pdm/init/README.md
@@ -65,8 +65,10 @@ jobs:
 | `has_docker` | Whether the project a Docker image (aka. a `Dockerfile` present at root) |
 | `has_src` | Whether the project is using a `src` layout or not |
 | `has_backstage` | Whether the project is exposing Backstage catalog infos |
+| `is_distribution` | Whether the project is a distribution or not |
 | `is_pr` | Is the current workflow run a pull-request |
 | `branch` | The branch from which workflow has been triggered |
+| `has_jfrog` | Whether this project uses JFrog Artifactory or not |
 | `jfrog-domain` | Base domain of Ledger's JFrog platform if authenticated |
 | `jfrog-url` | Base URL of Ledger's JFrog platform if authenticated |
 | `jfrog-user` | Username extracted from the OIDC token if authenticated |

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -52,12 +52,18 @@ outputs:
   has_backstage:
     description: Whether the project is exposing Backstage catalog infos
     value: ${{ steps.meta.outputs.has_backstage }}
+  is_distribution:
+    description: Whether the project is a distribution or not
+    value: ${{ steps.meta.outputs.is_distribution }}
   is_pr:
     description: Is the current workflow run a pull-request
     value: ${{ steps.meta.outputs.is_pr }}
   branch:
     description: The branch from which workflow has been triggered
     value: ${{ steps.meta.outputs.branch }}
+  has_jfrog:
+    description: Whether this project uses JFrog Artifactory or not
+    value: ${{ steps.detect-jfrog.outputs.has_jfrog }}
   jfrog-domain:
     description: Base domain of Ledger's JFrog platform if authenticated
     value: ${{ steps.jfrog-login.outputs.jfrog-domain }}
@@ -88,9 +94,17 @@ runs:
         git config user.email github-actions@ledger.fr
       shell: bash
 
+    - name: detect-jfrog
+      id: detect-jfrog
+      run: |
+        : Detect JFrog requirement
+        HAS_JFROG=$(grep "jfrog" pyproject.toml > /dev/null && echo "true" || echo "false")
+        echo "has_jfrog=${HAS_JFROG}" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Authenticate against JFrog Artifactory
       id: jfrog-login
-      if: env.JFROG_REPOSITORY
+      if: steps.detect-jfrog.outputs.has_jfrog == 'true' || env.JFROG_REPOSITORY
       uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
 
     - name: Set up Python and PDM
@@ -155,6 +169,9 @@ runs:
 
         IS_PR="${{ github.event_name == 'pull_request' }}"
         echo "is_pr=${IS_PR}" >> $GITHUB_OUTPUT
+
+        IS_DIST==$(grep -E "distribution\s*=\s*true" pyproject.toml > /dev/null && echo "true" || echo "false")
+        echo "is_distribution=${IS_DIST}" >> $GITHUB_OUTPUT
       env:
         PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token }}
       shell: bash

--- a/pdm/release/README.md
+++ b/pdm/release/README.md
@@ -48,7 +48,7 @@ jobs:
 
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
-| `kind` | Kind of project to release (lib/app) | `app` | `true` |
+| `kind` | DEPRECATED (Set `tool.pdm.distribution=true` on libraries) | `app` | `false` |
 | `pypi-token` | A Token to publish on PyPI (private or public) | `""` | `false` |
 | `github-token` | A Github token with proper permissions | `""` | `true` |
 | `increment` | Kind of increment (optional: `MAJOR\|MINOR\|PATCH`) | `""` | `false` |
@@ -56,7 +56,7 @@ jobs:
 | `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
 | `public` | Is it a public library ? | `false` | `false` |
 | `dgoss-args` | `dgoss` extra docker parameters | `""` | `false` |
-| `artifactory-repository` | Artifactory repository to publish to (deprecated for `JFROG_REPOSITORY`) | `""` | `false` |
+| `artifactory-repository` | DEPRECATED (Use `JFROG_REPOSITORY` environment variable) | `""` | `false` |
 | `docker-name` | Optionally override the docker image name (default to the repository name) | `""` | `false` |
 | `extra-docker` | An optional extra docker image to build | `""` | `false` |
 
@@ -64,7 +64,7 @@ jobs:
 
 | Variable | Description |
 |--------|-------------|
-| `JFROG_REPOSITORY` | JFrog repository used to fetch internal dependencies (triggers authentication) |
+| `JFROG_REPOSITORY` | JFrog repository to publish libraries on (triggers authentication and publication) |
 | `JFROG_DOCKER_REPOSITORY` | JFrog repository to publish images to (triggers authentication and publication) |
 
 ## Outputs

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -12,9 +12,8 @@ description: |
 
 inputs:
   kind:
-    description: Kind of project to release (lib/app)
-    required: true
-    default: app
+    description: DEPRECATED (Set `tool.pdm.distribution=true` on libraries)
+    default: ""
   pypi-token:
     description: A Token to publish on PyPI (private or public)
     required: false
@@ -38,7 +37,7 @@ inputs:
     description: "`dgoss` extra docker parameters"
     default: ""
   artifactory-repository:
-    description: Artifactory repository to publish to (deprecated for `JFROG_REPOSITORY`)
+    description: DEPRECATED (Use `JFROG_REPOSITORY` environment variable)
     default: ""
   docker-name:
     description: Optionally override the docker image name (default to the repository name)
@@ -76,6 +75,9 @@ runs:
           echo "⚠️ \`artifactory-repository\` input is deprecated, use the \`JFROG_REPOSITORY\` environment variable"
           echo "JFROG_REPOSITORY=${{ inputs.artifactory-repository }}" >> $GITHUB_ENV
         fi
+        if [ "${{ inputs.kind }}" != "" ]; then
+          echo "⚠️ \`input\` input is deprecated, set \`tool.pdm.distribution=true\` in \`pyproject.toml\` instead"
+        fi
       shell: bash
     - name: Clone and install dependencies
       uses: LedgerHQ/actions/pdm/init@main
@@ -108,7 +110,7 @@ runs:
 
     # Build once to publish the same package on every repository
     - name: Build distribution
-      if: inputs.kind == 'lib'
+      if: inputs.kind == 'lib' || steps.meta.outputs.is_distribution == 'true'
       run: |
         : Build distribution
         pdm build
@@ -126,7 +128,7 @@ runs:
 
     - name: Push to GemFury
       id: gemfury
-      if: inputs.kind == 'lib' && inputs.public != 'true' && env.PDM_PUBLISH_USERNAME != null
+      if: (inputs.kind == 'lib' || steps.meta.outputs.is_distribution == 'true') && inputs.public != 'true' && env.PDM_PUBLISH_USERNAME != null
       env:
         PDM_PUBLISH_REPO: https://push.fury.io/ledger
         PDM_PUBLISH_USERNAME: ${{ inputs.pypi-token }}
@@ -137,13 +139,9 @@ runs:
         pdm publish --no-build
       shell: bash
 
-    - name: Login to JFrog Ledger
-      if: inputs.kind == 'lib' && inputs.public != 'true'
-      uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
-
     - name: Push to our internal JFrog Artifactory
       id: artifactory
-      if: inputs.kind == 'lib' && inputs.public != 'true' && env.JFROG_URL
+      if: (inputs.kind == 'lib' || steps.meta.outputs.is_distribution == 'true') && inputs.public != 'true' && env.JFROG_REPOSITORY
       env:
         PDM_PUBLISH_REPO: ${{ env.JFROG_URL }}/artifactory/api/pypi/${{ env.JFROG_REPOSITORY }}
         PDM_PUBLISH_USERNAME: ${{ env.JFROG_USER }}
@@ -168,7 +166,7 @@ runs:
 
     - name: Push to PyPI
       id: pypi
-      if: inputs.kind == 'lib' && inputs.public == 'true' && env.PDM_PUBLISH_PASSWORD != null
+      if: (inputs.kind == 'lib' || steps.meta.outputs.is_distribution == 'true') && inputs.public == 'true' && env.PDM_PUBLISH_PASSWORD != null
       env:
         PDM_PUBLISH_PASSWORD: ${{ inputs.pypi-token }}
         FORCE_COLOR: 'true'


### PR DESCRIPTION
Detect and expose JFrog Artifactory support as well as distribution kind in `init`.
Deprecate `pdm/release` `kind` parameter

## Sample runs

- backward compatible:
	- CI: https://github.com/LedgerHQ/les-copier-demo/actions/runs/12139059509
	- Release: https://github.com/LedgerHQ/les-copier-demo/actions/runs/12139919227
- CI without `jFROG_REPOSITORY` var: https://github.com/LedgerHQ/les-copier-demo/actions/runs/12140111126
- Release without `kind`: https://github.com/LedgerHQ/les-copier-demo/actions/runs/12140492728