### PR TITLE
fix(jfrog): avoid double authentication

### DIFF
--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -62,7 +62,7 @@ runs:
 
     - name: Authenticate against JFrog Artifactory
       id: jfrog-login
-      if: env.JFROG_REPOSITORY || env.JFROG_DOCKER_REPOSITORY
+      if: (env.JFROG_REPOSITORY || env.JFROG_DOCKER_REPOSITORY) && !env.JFROG_TOKEN
       uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
 
     - name: Login to JFrog Artifactory internal registry

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -104,7 +104,7 @@ runs:
 
     - name: Authenticate against JFrog Artifactory
       id: jfrog-login
-      if: steps.detect-jfrog.outputs.has_jfrog == 'true' || env.JFROG_REPOSITORY
+      if: (steps.detect-jfrog.outputs.has_jfrog == 'true' || env.JFROG_REPOSITORY) && !env.JFROG_TOKEN
       uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
 
     - name: Set up Python and PDM


### PR DESCRIPTION
Avoid JFrog double authentication:
- faster
- removes some warnings on cleanup