### PR TITLE
fix(pdm): only keep latest documentation by `<major>.<minor>`

### DIFF
--- a/pdm/doc/publish/action.yml
+++ b/pdm/doc/publish/action.yml
@@ -64,7 +64,8 @@ runs:
       if: inputs.site == 'true' && inputs.version || startsWith(github.ref, 'refs/tags')
       run: |
         : Deploy the documentation site \(tag\)
-        pdm doc:deploy --push ${{ inputs.version || github.head_ref || github.ref_name }}
+        version="${{ inputs.version || github.head_ref || github.ref_name }}"
+        pdm doc:deploy --push ${version%.*}
       env:
         FORCE_COLOR: 'true'
       shell: bash


### PR DESCRIPTION
To avoid filling `gh-pages` branch, reaching GitHub pages size limitation and to unclutter the version selector, we only keep the latest documentation version by `<major>.<minor>`.

Same change as https://github.com/LedgerHQ/ledger-vault-api/pull/5134 (Gate has reach `gh-pages` size limit)