### PR TITLE
fix(pdm): allow to replaying the `report` job in case of savage runner restart

### DIFF
--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -137,6 +137,7 @@ runs:
     - name: Merge reports artifacts
       if: inputs.report-only
       uses: actions/upload-artifact/merge@v4
+      continue-on-error: true
       with:
         name: reports
         pattern: reports-*


### PR DESCRIPTION
When self-hosted runners are brutally and savagely restarted during a `repoort` job, you have to rerun the entire workflow because artifacts were already merged.
This makes the `report` job replayable even artifacts have been merged
