### PR TITLE
fix(pdm): fix bad JFROG secrets on 2n docker build-push

### DIFF
--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -193,8 +193,8 @@ runs:
           ${{ inputs.build-args }}
         secrets: |
           PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token }}
-          JFROG_USER=${{ steps.jfrog-login.outputs.oidc-user }}
-          JFROG_TOKEN=${{ steps.jfrog-login.outputs.oidc-token }}
+          JFROG_USER=${{ env.JFROG_USER }}
+          JFROG_TOKEN=${{ env.JFROG_TOKEN }}
           ${{ inputs.secrets }}
         pull: ${{ steps.vars.outputs.has_goss != 'true' }}
         push: true


### PR DESCRIPTION
Fixes bad JFROG secrets on 2n docker build-push that only happens for single-pass docker builds without `goss`.
The JFrog login step is only executed if credentials are not present in the environment. We need to check always check and fetch credentials from the environment.