### PR TITLE
fix(pdm): restore the OpenAPI doc generation on release

### DIFF
--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -223,7 +223,7 @@ runs:
       with:
         version: ${{ env.REVISION }}
         pypi-token: ${{ inputs.pypi-token }}
-        openapi: ${{ inputs.kind == 'app' && steps.meta.outputs.has_openapi == 'true' }}
+        openapi: ${{ steps.meta.outputs.has_openapi == 'true' }}
         site: true
         init: false
 


### PR DESCRIPTION
This PR fixes the OpenAPI generation on release, which was still binded to the deprecated `kind` parameter.