### PR TITLE
fix(pdm): `github-token` and permissions consistency

### DIFF
--- a/openapi/diff/README.md
+++ b/openapi/diff/README.md
@@ -10,6 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: LedgerHQ/actions/openapi/diff@main
+        with
+          base: path/to/base/openapi.yaml
+          head: path/to/head/openapi.yaml
+          output: path/to/output/directory
+          github-token: ${{ github.token }}
+```
+
+## Permissions
+
+This action interact with the GitHub API using the GitHub token and requires the following permissions:
+
+```yaml
+pull-requests: write  # to comment on the PR
 ```
 
 ## Inputs
@@ -19,6 +32,7 @@ jobs:
 | `base` | Base diff specification file | `""` | `true` |
 | `head` | Head diff specification file | `""` | `true` |
 | `output` | Output directory | `reports/openapi` | `true` |
+| `github-token` | A GitHub token with `pull-requests: write` permissions | `${{ github.token }}` | `false` |
 
 ## Outputs
 

--- a/openapi/diff/action.yml
+++ b/openapi/diff/action.yml
@@ -12,6 +12,9 @@ inputs:
     description: Output directory
     required: true
     default: reports/openapi
+  github-token:
+    description: 'A GitHub token with `pull-requests: write` permissions'
+    default: ${{ github.token }}
 
 outputs:
   markdown:
@@ -70,10 +73,11 @@ runs:
 
     - name: Comment PR with OpenAPI diff
       if: github.event_name == 'pull_request'
-      uses: thollander/actions-comment-pull-request@v2
+      uses: thollander/actions-comment-pull-request@v3
       with:
         filePath: ${{ steps.generate.outputs.comment }}
         comment_tag: openapi-diff
+        github-token: ${{ inputs.github-token }}
 
     - uses: actions/upload-artifact@v4
       with:

--- a/pdm/doc/build/README.md
+++ b/pdm/doc/build/README.md
@@ -12,31 +12,25 @@ jobs:
       - uses: LedgerHQ/actions/pdm/doc/build@main
 ```
 
-> [!IMPORTANT]
-> JFrog Artifactory dependencies requires authentication.
-> As a consequence, you need to enable the `id-token` permission if you rely on it.
->
-> ```yaml
-> jobs:
->   build-doc:
->     runs-on: ubuntu-latest
->     permissions:
->       contents: read
->       id-token: write
->     steps:
->       - uses: LedgerHQ/actions/pdm/build-doc@main
->         env:
->           JFROG_REPOSITORY: my-team-repository
-> ```
->
-> See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
+## Permissions
+
+This action interact with the GitHub API using the GitHub token and requires the following permissions:
+
+```yaml
+contents: read  # Checkout
+id-token: write  # JFrog Artifactory authentication
+pull-requests: write  # to comment on the PR (OpenAPI diff only)
+```
+
+See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
 
 ## Inputs
 
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
 | `python-version` | Python version used to build | `3.11` | `false` |
-| `pypi-token` | A read token for private PyPI access | `""` | `false` |
+| `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
+| `pypi-token` | ~~Private PyPI token (GemFury read)~~ **deprecated:** _use JFrog instead_ | `""` | `false` |
 | `openapi` | Whether or not to build OpenAPI specs | `false` | `false` |
 | `site` | Whether or not to build a documentation site | `false` | `false` |
 | `init` | Clone & sync | `true` | `false` |

--- a/pdm/doc/build/action.yml
+++ b/pdm/doc/build/action.yml
@@ -6,9 +6,15 @@ inputs:
     description: Python version used to build
     required: false
     default: "3.11"
-  pypi-token:
-    description: A read token for private PyPI access
+  github-token:
+    description: A Github token with proper permissions
     required: false
+    default: ${{ github.token }}
+  pypi-token:
+    description: Private PyPI token (GemFury read)
+    required: false
+    default: ""
+    deprecationMessage: use JFrog instead
   openapi:
     description: Whether or not to build OpenAPI specs
     default: 'false'
@@ -139,3 +145,4 @@ runs:
       with:
         base: openapi.base.yaml
         head: openapi.head.yaml
+        github-token: ${{ inputs.github-token }}

--- a/pdm/doc/publish/README.md
+++ b/pdm/doc/publish/README.md
@@ -12,24 +12,16 @@ jobs:
       - uses: LedgerHQ/actions/pdm/doc/publish@main
 ```
 
-> [!IMPORTANT]
-> JFrog Artifactory dependencies requires authentication.
-> As a consequence, you need to enable the `id-token` permission if you rely on it.
->
-> ```yaml
-> jobs:
->   publish-doc:
->     runs-on: ubuntu-latest
->     permissions:
->       contents: read
->       id-token: write
->     steps:
->       - uses: LedgerHQ/actions/pdm/publish-doc@main
->         env:
->           JFROG_REPOSITORY: my-team-repository
-> ```
->
-> See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
+## Permissions
+
+This action interact with the GitHub API using the GitHub token and requires the following permissions:
+
+```yaml
+contents: read  # Checkout
+id-token: write  # JFrog Artifactory authentication
+```
+
+See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
 
 ## Inputs
 
@@ -38,7 +30,7 @@ jobs:
 | `version` | Force a version to be built | `""` | `false` |
 | `openapi` | Has OpenAPI specs | `false` | `false` |
 | `site` | Publish a documentation site | `false` | `false` |
-| `pypi-token` | A read token for private PyPI access | `""` | `false` |
+| `pypi-token` | ~~Private PyPI token (GemFury read)~~ **deprecated:** _use JFrog instead_ | `""` | `false` |
 | `init` | Clone & sync | `true` | `false` |
 | `group` | Dependency group(s) to install | `docs` | `false` |
 | `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |

--- a/pdm/doc/publish/action.yml
+++ b/pdm/doc/publish/action.yml
@@ -12,8 +12,10 @@ inputs:
     description: Publish a documentation site
     default: 'false'
   pypi-token:
-    description: A read token for private PyPI access
+    description: Private PyPI token (GemFury read)
     required: false
+    default: ""
+    deprecationMessage: use JFrog instead
   init:
     description: Clone & sync
     default: 'true'

--- a/pdm/docker/README.md
+++ b/pdm/docker/README.md
@@ -12,29 +12,17 @@ jobs:
       - uses: LedgerHQ/actions/pdm/docker@main
 ```
 
-> [!IMPORTANT]
-> JFrog Artifactory dependencies requires authentication.
-> As a consequence, you need to enable the `id-token` permission if you rely on it (to build or publish).
->
-> When publishing on JFrog Artifactory, this action will also sign and attest the produced images,
-> so it will also need the `attestations` permission.
->
-> ```yaml
-> jobs:
->   docker:
->     runs-on: ubuntu-latest
->     permissions:
->       contents: read
->       id-token: write
->       attestations: write
->     steps:
->       - uses: LedgerHQ/actions/pdm/docker@main
->         env:
->           JFROG_REPOSITORY: my-team-repository
->           JFROG_DOCKER_REPOSITORY: my-team-docker-repository
-> ```
->
-> See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
+## Permissions
+
+This action interact with the GitHub API using the GitHub token and requires the following permissions:
+
+```yaml
+contents: read  # Checkout
+id-token: write  # JFrog Artifactory authentication
+attestations: write  # Attestation permission
+```
+
+See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
 
 ## Inputs
 
@@ -42,8 +30,8 @@ jobs:
 |-------|-------------|---------|----------|
 | `clone` | Whether to clone or not | `true` | `false` |
 | `version` | Force the built version | `""` | `false` |
-| `pypi-token` | A Token to Ledger private PyPI with read permissions (GemFury, deprecated) | `""` | `false` |
-| `github-token` | A Github token with proper permissions | `""` | `false` |
+| `pypi-token` | ~~Private PyPI token (GemFury read)~~ **deprecated:** _use JFrog instead_ | `""` | `false` |
+| `github-token` | A GitHub token with proper permissions | `${{ github.token }}` | `false` |
 | `build-args` | Docker build command extra `build-args` (multiline supported) | `""` | `false` |
 | `secrets` | Docker build command extra `secrets` (multiline supported) | `""` | `false` |
 | `dgoss-args` | dgoss extra docker parameters | `""` | `false` |

--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -8,10 +8,13 @@ inputs:
   version:
     description: Force the built version
   pypi-token:
-    description: A Token to Ledger private PyPI with read permissions (GemFury, deprecated)
+    description: Private PyPI token (GemFury read)
     required: false
+    default: ""
+    deprecationMessage: use JFrog instead
   github-token:
-    description: A Github token with proper permissions
+    description: A GitHub token with proper permissions
+    default: ${{ github.token }}
   build-args:
     description: Docker build command extra `build-args` (multiline supported)
     default: ""

--- a/pdm/init/README.md
+++ b/pdm/init/README.md
@@ -35,6 +35,17 @@ jobs:
 >
 > See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
 
+## Permissions
+
+This action interact with the GitHub API using the GitHub token and requires the following permissions:
+
+```yaml
+contents: read  # Checkout
+id-token: write # Authenticate to JFrog Artifactory
+```
+
+See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
+
 ## Inputs
 
 | Input | Description | Default | Required |
@@ -43,7 +54,7 @@ jobs:
 | `group` | Dependency group(s) to install | `""` | `false` |
 | `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
 | `history` | Fetch the full history | `false` | `false` |
-| `pypi-token` | Private PyPI token (GemFury read, deprecated) | `""` | `false` |
+| `pypi-token` | ~~Private PyPI token (GemFury read)~~ **deprecated:** _use JFrog instead_ | `""` | `false` |
 | `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
 | `skip-dependencies` | Skip dependencies installation | `""` | `false` |
 

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -17,9 +17,10 @@ inputs:
     required: false
     default: 'false'
   pypi-token:
-    description: Private PyPI token (GemFury read, deprecated)
+    description: Private PyPI token (GemFury read)
     required: false
     default: ""
+    deprecationMessage: use JFrog instead
   github-token:
     description: A Github token with proper permissions
     required: false

--- a/pdm/release/README.md
+++ b/pdm/release/README.md
@@ -20,35 +20,23 @@ jobs:
       - uses: LedgerHQ/actions/pdm/release@main
 ```
 
-> [!IMPORTANT]
-> JFrog Artifactory dependencies requires authentication.
-> As a consequence, you need to enable the `id-token` permission if you rely on it.
->
-> When publishing on JFrog Artifactory, this action will also sign and attest the produced packages,
-> so it will also need the `attestations` permission.
->
-> ```yaml
-> jobs:
->   test:
->     runs-on: ubuntu-latest
->     permissions:
->       contents: read
->       id-token: write
->       attestations: write
->     steps:
->       - uses: LedgerHQ/actions/pdm/release@main
->         env:
->           JFROG_REPOSITORY: my-team-repository
->           JFROG_DOCKER_REPOSITORY: my-team-docker-repository
-> ```
->
-> See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
+## Permissions
+
+This action interact with the GitHub API using the GitHub token and requires the following permissions:
+
+```yaml
+contents: read       # Checkout
+id-token: write      # JFrog Artifactory authentication
+attestations: write  # Attestation permission
+```
+
+See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
 
 ## Inputs
 
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
-| `kind` | DEPRECATED (Set `tool.pdm.distribution=true` on libraries) | `app` | `false` |
+| `kind` | DEPRECATED (Set `tool.pdm.distribution=true` on libraries) | `""` | `false` |
 | `pypi-token` | A Token to publish on PyPI (private or public) | `""` | `false` |
 | `github-token` | A Github token with proper permissions | `""` | `true` |
 | `increment` | Kind of increment (optional: `MAJOR\|MINOR\|PATCH`) | `""` | `false` |

--- a/pdm/release/pre/README.md
+++ b/pdm/release/pre/README.md
@@ -15,12 +15,22 @@ jobs:
           github-token: ${{ github.token }}
 ```
 
+## Permissions
+
+This action interact with the GitHub API using the GitHub token and requires the following permissions:
+
+```yaml
+actions: read
+checks: read
+contents: read
+```
+
 ## Inputs
 
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
 | `workflow` | Required workflow file | `ci.yml` | `false` |
-| `github-token` | A Github token with proper permissions | `""` | `true` |
+| `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
 
 ## Outputs
 

--- a/pdm/release/pre/action.yml
+++ b/pdm/release/pre/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: ci.yml
   github-token:
     description: A Github token with proper permissions
-    required: true
+    default: ${{ github.token }}
 
 runs:
   using: composite

--- a/pdm/test/README.md
+++ b/pdm/test/README.md
@@ -12,31 +12,24 @@ jobs:
       - uses: LedgerHQ/actions/pdm/test@main
 ```
 
-> [!IMPORTANT]
-> JFrog Artifactory dependencies requires authentication.
-> As a consequence, you need to enable the `id-token` permission if you rely on it.
->
-> ```yaml
-> jobs:
->   test:
->     runs-on: ubuntu-latest
->     permissions:
->       contents: read
->       id-token: write
->     steps:
->       - uses: LedgerHQ/actions/pdm/test@main
->         env:
->           JFROG_REPOSITORY: my-team-repository
-> ```
->
-> See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
+## Permissions
+
+This action interact with the GitHub API using the GitHub token and requires the following permissions:
+
+```yaml
+contents: read  # Checkout
+id-token: write  # JFrog Artifactory authentication
+pull-requests: write  # to comment on the PR (OpenAPI diff only)
+```
+
+See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
 
 ## Inputs
 
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
 | `python-version` | Python version to run the tests with | `3.11` | `true` |
-| `pypi-token` | A Token to Ledger private PyPI with read permissions | `""` | `true` |
+| `pypi-token` | ~~Private PyPI token (GemFury read)~~ **deprecated:** _use JFrog instead_ | `""` | `false` |
 | `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
 | `init` | Clone & sync | `true` | `false` |
 | `parameters` | Some extra parameters to pass to `pdm cover` | `""` | `false` |

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -7,9 +7,10 @@ inputs:
     required: true
     default: "3.11"
   pypi-token:
-    description: A Token to Ledger private PyPI with read permissions
-    required: true
+    description: Private PyPI token (GemFury read)
+    required: false
     default: ""
+    deprecationMessage: use JFrog instead
   github-token:
     description: A Github token with proper permissions
     default: ${{ github.token }}


### PR DESCRIPTION
This PR ensure we can use both the `CI_BOT_TOKEN` and `github.token` with proper permission in all `pdm` actions as well as in the `openapi/diff` action.
It also documents all required permissions for those actions.

> [!NOTE]
> `pdm/release` action is still requiring a PAT as it relies on specific permissions in the repository setting to be able to push on the branch without a PR. I might need some investigation to ensure we can use the builtin `github.token`

Also, PyPI token deprecation has been properly flagged and documented