### PR TITLE
doc(pdm): document the `packages: write` permission for Docker image publication to ghcr.io

### DIFF
--- a/pdm/docker/README.md
+++ b/pdm/docker/README.md
@@ -17,9 +17,10 @@ jobs:
 This action interact with the GitHub API using the GitHub token and requires the following permissions:
 
 ```yaml
-contents: read  # Checkout
-id-token: write  # JFrog Artifactory authentication
+contents: read       # Checkout
+id-token: write      # JFrog Artifactory authentication
 attestations: write  # Attestation permission
+packages: write      # Docker image publication on ghcr
 ```
 
 See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)

--- a/pdm/release/README.md
+++ b/pdm/release/README.md
@@ -28,6 +28,7 @@ This action interact with the GitHub API using the GitHub token and requires the
 contents: read       # Checkout
 id-token: write      # JFrog Artifactory authentication
 attestations: write  # Attestation permission
+packages: write      # Docker image publication on ghcr
 ```
 
 See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)


### PR DESCRIPTION
Document the required `packages: write` permission for jdocker publication to ghcr.io