### PR TITLE
fix(pdm): only warn on when pypi-token is actually set

### DIFF
--- a/pdm/doc/build/action.yml
+++ b/pdm/doc/build/action.yml
@@ -13,7 +13,6 @@ inputs:
   pypi-token:
     description: Private PyPI token (GemFury read)
     required: false
-    default: ""
     deprecationMessage: use JFrog instead
   openapi:
     description: Whether or not to build OpenAPI specs

--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -10,7 +10,6 @@ inputs:
   pypi-token:
     description: Private PyPI token (GemFury read)
     required: false
-    default: ""
     deprecationMessage: use JFrog instead
   github-token:
     description: A GitHub token with proper permissions
@@ -144,7 +143,7 @@ runs:
           JFROG_REPOSITORY=${{ env.JFROG_REPOSITORY }}
           ${{ inputs.build-args }}
         secrets: |
-          PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token }}
+          PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token || "" }}
           JFROG_USER=${{ env.JFROG_USER }}
           JFROG_TOKEN=${{ env.JFROG_TOKEN }}
           ${{ inputs.secrets }}
@@ -195,7 +194,7 @@ runs:
           JFROG_REPOSITORY=${{ env.JFROG_REPOSITORY }}
           ${{ inputs.build-args }}
         secrets: |
-          PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token }}
+          PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token || "" }}
           JFROG_USER=${{ env.JFROG_USER }}
           JFROG_TOKEN=${{ env.JFROG_TOKEN }}
           ${{ inputs.secrets }}

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -19,7 +19,6 @@ inputs:
   pypi-token:
     description: Private PyPI token (GemFury read)
     required: false
-    default: ""
     deprecationMessage: use JFrog instead
   github-token:
     description: A Github token with proper permissions
@@ -114,7 +113,7 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: true
       env:
-        PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token }}
+        PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token || '' }}
 
     - name: Set some settings
       run: |
@@ -133,7 +132,7 @@ runs:
         [ "${{ runner.debug }}" == "1" ] && params+=(-vv)
         pdm sync "${params[@]}"
       env:
-        PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token }}
+        PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token || ''  }}
         GROUPS: ${{ inputs.group }}
         EXCLUDED_GROUPS: ${{ inputs.exclude-group }}
       shell: bash
@@ -174,5 +173,5 @@ runs:
         IS_DIST=$(grep -E "distribution\s*=\s*true" pyproject.toml > /dev/null && echo "true" || echo "false")
         echo "is_distribution=${IS_DIST}" >> $GITHUB_OUTPUT
       env:
-        PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token }}
+        PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token || ''  }}
       shell: bash

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -17,7 +17,6 @@ inputs:
   pypi-token:
     description: A Token to publish on PyPI (private or public)
     required: false
-    default: ""
   github-token:
     description: A Github token with proper permissions
     required: true
@@ -131,7 +130,7 @@ runs:
       if: (inputs.kind == 'lib' || steps.meta.outputs.is_distribution == 'true') && inputs.public != 'true' && env.PDM_PUBLISH_USERNAME != null
       env:
         PDM_PUBLISH_REPO: https://push.fury.io/ledger
-        PDM_PUBLISH_USERNAME: ${{ inputs.pypi-token }}
+        PDM_PUBLISH_USERNAME: ${{ inputs.pypi-token || '' }}
         PDM_PUBLISH_PASSWORD: "-" # tricks github actions YAML parser and PDM test for empty password
         FORCE_COLOR: 'true'
       run: |

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -9,7 +9,6 @@ inputs:
   pypi-token:
     description: Private PyPI token (GemFury read)
     required: false
-    default: ""
     deprecationMessage: use JFrog instead
   github-token:
     description: A Github token with proper permissions


### PR DESCRIPTION
Avoid the deprecation warning when Pypi Token is not set

> [!NOTE]
> Maybe it's time to simply get ride of those deprecations