### PR TITLE
fix(pdm): restore the workspace after OpenAPI diff for next tasks

### DIFF
--- a/pdm/doc/build/action.yml
+++ b/pdm/doc/build/action.yml
@@ -103,10 +103,15 @@ runs:
       shell: bash
 
     - name: Checkout base ref
+      id: checkout-base
       if: success() && steps.init.outputs.is_pr == 'true' && inputs.openapi == 'true'
       continue-on-error: true  # OpenAPI diff is optional
       run: |
         : Checkout base ref
+        # Store the ref to restore it later
+        CURRENT_REF=$(git rev-parse HEAD)
+        echo "backup-ref=${CURRENT_REF}" >> $GITHUB_OUTPUT
+
         # Clean dirty state before trying to switch branch
         git restore .
         git checkout ${{ github.base_ref }}
@@ -146,3 +151,12 @@ runs:
         base: openapi.base.yaml
         head: openapi.head.yaml
         github-token: ${{ inputs.github-token }}
+
+    - name: Restore checked out ref and state
+      if: success() && jobs.checkout-base.outcome == 'success'
+      run: |
+        : Restore the checked out ref and state
+        git restore .
+        git checkout ${{ steps.checkout-base.outputs.backup-ref }}
+        mv openapi.head.yaml docs/openapi.yaml
+      shell: bash


### PR DESCRIPTION
Ensure that following tasks can actually access workspace assets from the current ref and still read the openapi spec from its expected location.

> [!NOTE]
> This suggest that maybe the OpenAPI generation and diff should be splitted into their own action/job