### PR TITLE
feat(pdm): expose `release/pre` wait parameters and enable it by default

### DIFF
--- a/pdm/release/pre/README.md
+++ b/pdm/release/pre/README.md
@@ -13,7 +13,13 @@ jobs:
         with:
           workflow: check.yml
           github-token: ${{ github.token }}
+          wait-interval: 60
+          wait-timeout: 300
 ```
+
+> [!WARNING]
+> Each poll use performimg multiple GitHub API calls.
+> Be careful with the `wait-interval` and `wait-timeout` values.
 
 ## Permissions
 
@@ -30,7 +36,10 @@ contents: read
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
 | `workflow` | Required workflow file | `ci.yml` | `false` |
-| `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
+| `github-token` | A GitHub token with proper permissions | `${{ github.token }}` | `false` |
+| `wait` | Wait for the workflow to finish | `true` | `false` |
+| `wait-interval` | Interval (in seconds) to check the workflow status | `30` | `false` |
+| `wait-timeout` | Timeout (in seconds) to stop checking the workflow status | `600` | `false` |
 
 ## Outputs
 

--- a/pdm/release/pre/action.yml
+++ b/pdm/release/pre/action.yml
@@ -6,8 +6,17 @@ inputs:
     description: Required workflow file
     default: ci.yml
   github-token:
-    description: A Github token with proper permissions
+    description: A GitHub token with proper permissions
     default: ${{ github.token }}
+  wait:
+    description: Wait for the workflow to finish
+    default: "true"
+  wait-interval:
+    description: Interval (in seconds) to check the workflow status
+    default: "30"
+  wait-timeout:
+    description: Timeout (in seconds) to stop checking the workflow status
+    default: "600"
 
 runs:
   using: composite
@@ -17,6 +26,9 @@ runs:
       with:
         workflow: ${{ inputs.workflow }}
         token: ${{ inputs.github-token }}
+        wait: ${{ inputs.wait }}
+        wait_interval: ${{ inputs.wait-interval }}
+        wait_timeout: ${{ inputs.wait-timeout }}
     - name: Notify failure
       if: failure()
       run: |


### PR DESCRIPTION
This PR expose 3 new `pdm/release/pre` parameters: 
- `wait` (`true`/`false`): enable active wait (will wait for the CI workflow to end, if in progress)
- `wait-interval` (seconds as `int`): polling interval during wait
- `wait-timeout` (seconds as `int`): max time to wait before cancelling the release

`wait` is enabled by default with 1 poll every 30s for 10min