### PR TITLE
fix(pdm): force the latest Docker BuildX

### DIFF
--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -79,6 +79,11 @@ runs:
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        # Default behavior is to use the latest available version on the runner
+        # but the runner version is too old to handle GHA new cache
+        # cf. https://github.com/docker/build-push-action/issues/1345#issuecomment-2770572479
+        version: latest
 
     - name: Compute some variables
       id: vars


### PR DESCRIPTION
This should prepare for the next GitHub Legacy cache brownout (April 8th) by forcing the latest BuildX version instead of relying on the one providing by the runner.

See:
- https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts for the context
- https://github.com/docker/build-push-action/issues/1345#issuecomment-2770572479 for the solution