### PR TITLE
refactor(pdm): drop the deprecated support for GemFury

### DIFF
--- a/pdm/doc/README.md
+++ b/pdm/doc/README.md
@@ -19,7 +19,6 @@ jobs:
 | `version` | Force a version to be built | `""` | `false` |
 | `openapi` | Has OpenAPI specs | `false` | `false` |
 | `site` | Publish a documentation site | `false` | `false` |
-| `pypi-token` | A read token for private PyPI access | `""` | `false` |
 | `init` | Clone & sync | `true` | `false` |
 | `python-version` | Python version used to build | `""` | `false` |
 

--- a/pdm/doc/action.yml
+++ b/pdm/doc/action.yml
@@ -11,9 +11,6 @@ inputs:
   site:
     description: Publish a documentation site
     default: 'false'
-  pypi-token:
-    description: A read token for private PyPI access
-    required: false
   init:
     description: Clone & sync
     default: 'true'
@@ -32,14 +29,12 @@ runs:
       with:
         init: ${{ inputs.init }}
         python-version: ${{ inputs.python-version }}
-        pypi-token: ${{ inputs.pypi-token }}
         openapi: ${{ inputs.openapi }}
         site: ${{ inputs.site }}
     - uses: LedgerHQ/actions/pdm/doc/publish@main
       id: publish
       with:
         init: false
-        pypi-token: ${{ inputs.pypi-token }}
         openapi: ${{ inputs.openapi }}
         site: ${{ inputs.site }}
         version: ${{ inputs.version }}

--- a/pdm/doc/build/README.md
+++ b/pdm/doc/build/README.md
@@ -30,7 +30,6 @@ See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/
 |-------|-------------|---------|----------|
 | `python-version` | Python version used to build | `""` | `false` |
 | `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
-| `pypi-token` | ~~Private PyPI token (GemFury read)~~ **deprecated:** _use JFrog instead_ | `""` | `false` |
 | `openapi` | Whether or not to build OpenAPI specs. Valid values are: "true" (to generate new specs and run diff steps on PRs), "false" (to skip OpenAPI processing), or an artifact name (to download an existing OpenAPI spec). | `false` | `false` |
 | `site` | Whether or not to build a documentation site | `false` | `false` |
 | `init` | Clone & sync | `true` | `false` |

--- a/pdm/doc/build/action.yml
+++ b/pdm/doc/build/action.yml
@@ -8,10 +8,6 @@ inputs:
     description: A Github token with proper permissions
     required: false
     default: ${{ github.token }}
-  pypi-token:
-    description: Private PyPI token (GemFury read)
-    required: false
-    deprecationMessage: use JFrog instead
   openapi:
     description: >
       Whether or not to build OpenAPI specs. Valid values are: "true" (to generate new specs and run diff steps on PRs), "false" (to skip OpenAPI processing), or an artifact name (to download an existing OpenAPI spec).
@@ -41,7 +37,6 @@ runs:
         group: ${{ inputs.group }}
         exclude-group: ${{ inputs.exclude-group }}
         history: true
-        pypi-token: ${{ inputs.pypi-token }}
         python-version: ${{ inputs.python-version }}
 
     - name: Update the CHANGELOG

--- a/pdm/doc/publish/README.md
+++ b/pdm/doc/publish/README.md
@@ -30,7 +30,6 @@ See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/
 | `version` | Force a version to be built | `""` | `false` |
 | `openapi` | Has OpenAPI specs | `false` | `false` |
 | `site` | Publish a documentation site | `false` | `false` |
-| `pypi-token` | ~~Private PyPI token (GemFury read)~~ **deprecated:** _use JFrog instead_ | `""` | `false` |
 | `init` | Clone & sync | `true` | `false` |
 | `group` | Dependency group(s) to install | `docs` | `false` |
 | `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |

--- a/pdm/doc/publish/action.yml
+++ b/pdm/doc/publish/action.yml
@@ -11,11 +11,6 @@ inputs:
   site:
     description: Publish a documentation site
     default: 'false'
-  pypi-token:
-    description: Private PyPI token (GemFury read)
-    required: false
-    default: ""
-    deprecationMessage: use JFrog instead
   init:
     description: Clone & sync
     default: 'true'
@@ -43,7 +38,6 @@ runs:
         group: ${{ inputs.group }}
         exclude-group: ${{ inputs.exclude-group }}
         history: true
-        pypi-token: ${{ inputs.pypi-token }}
         python-version: ${{ inputs.python-version }}
 
     - uses: actions/download-artifact@v4

--- a/pdm/docker/README.md
+++ b/pdm/docker/README.md
@@ -31,7 +31,6 @@ See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/
 |-------|-------------|---------|----------|
 | `clone` | Whether to clone or not | `true` | `false` |
 | `version` | Force the built version | `""` | `false` |
-| `pypi-token` | ~~Private PyPI token (GemFury read)~~ **deprecated:** _use JFrog instead_ | `""` | `false` |
 | `github-token` | A GitHub token with proper permissions | `${{ github.token }}` | `false` |
 | `build-args` | Docker build command extra `build-args` (multiline supported) | `""` | `false` |
 | `secrets` | Docker build command extra `secrets` (multiline supported) | `""` | `false` |

--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -7,10 +7,6 @@ inputs:
     default: 'true'
   version:
     description: Force the built version
-  pypi-token:
-    description: Private PyPI token (GemFury read)
-    required: false
-    deprecationMessage: use JFrog instead
   github-token:
     description: A GitHub token with proper permissions
     default: ${{ github.token }}
@@ -148,7 +144,6 @@ runs:
           JFROG_REPOSITORY=${{ env.JFROG_REPOSITORY }}
           ${{ inputs.build-args }}
         secrets: |
-          PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token || '' }}
           JFROG_USER=${{ env.JFROG_USER }}
           JFROG_TOKEN=${{ env.JFROG_TOKEN }}
           ${{ inputs.secrets }}
@@ -199,7 +194,6 @@ runs:
           JFROG_REPOSITORY=${{ env.JFROG_REPOSITORY }}
           ${{ inputs.build-args }}
         secrets: |
-          PYPI_DEPLOY_TOKEN=${{ inputs.pypi-token || '' }}
           JFROG_USER=${{ env.JFROG_USER }}
           JFROG_TOKEN=${{ env.JFROG_TOKEN }}
           ${{ inputs.secrets }}

--- a/pdm/init/README.md
+++ b/pdm/init/README.md
@@ -54,7 +54,6 @@ See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/
 | `group` | Dependency group(s) to install | `""` | `false` |
 | `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |
 | `history` | Fetch the full history | `false` | `false` |
-| `pypi-token` | ~~Private PyPI token (GemFury read)~~ **deprecated:** _use JFrog instead_ | `""` | `false` |
 | `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
 | `skip-dependencies` | Skip dependencies installation | `""` | `false` |
 

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -14,10 +14,6 @@ inputs:
     description: Fetch the full history
     required: false
     default: 'false'
-  pypi-token:
-    description: Private PyPI token (GemFury read)
-    required: false
-    deprecationMessage: use JFrog instead
   github-token:
     description: A Github token with proper permissions
     required: false
@@ -117,8 +113,6 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: true
-      env:
-        PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token || '' }}
 
     - name: Set some settings
       run: |
@@ -137,7 +131,6 @@ runs:
         [ "${{ runner.debug }}" == "1" ] && params+=(-vv)
         pdm sync "${params[@]}"
       env:
-        PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token || ''  }}
         GROUPS: ${{ inputs.group }}
         EXCLUDED_GROUPS: ${{ inputs.exclude-group }}
       shell: bash
@@ -177,6 +170,4 @@ runs:
 
         IS_DIST=$(grep -E "distribution\s*=\s*true" pyproject.toml > /dev/null && echo "true" || echo "false")
         echo "is_distribution=${IS_DIST}" >> $GITHUB_OUTPUT
-      env:
-        PYPI_DEPLOY_TOKEN: ${{ inputs.pypi-token || ''  }}
       shell: bash

--- a/pdm/openapi/README.md
+++ b/pdm/openapi/README.md
@@ -31,7 +31,6 @@ See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/
 |-------|-------------|---------|----------|
 | `python-version` | Python version used to build | `""` | `false` |
 | `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
-| `pypi-token` | Private PyPI token | `""` | `false` |
 | `init` | Clone & sync | `true` | `false` |
 | `group` | Dependency group(s) to install | `docs` | `false` |
 | `exclude-group` | Dependency group(s) to exclude from install | `""` | `false` |

--- a/pdm/openapi/action.yml
+++ b/pdm/openapi/action.yml
@@ -15,9 +15,6 @@ inputs:
     description: A Github token with proper permissions
     required: false
     default: ${{ github.token }}
-  pypi-token:
-    description: Private PyPI token
-    required: false
   init:
     description: Clone & sync
     default: 'true'
@@ -45,7 +42,6 @@ runs:
         group: ${{ inputs.group }}
         history: true
         exclude-group: ${{ inputs.exclude-group }}
-        pypi-token: ${{ inputs.pypi-token }}
         python-version: ${{ inputs.python-version }}
 
     - name: Generate the OpenAPI specifications

--- a/pdm/release/action.yml
+++ b/pdm/release/action.yml
@@ -88,7 +88,6 @@ runs:
         exclude-group: ${{ inputs.exclude-group }}
         history: true
         github-token: ${{ inputs.github-token }}
-        pypi-token: ${{ inputs.pypi-token }}
         python-version: ${{ inputs.python-version }}
 
     - name: Bump using commitizen
@@ -126,19 +125,6 @@ runs:
     # Successful actions will need cleanup 🧹 in case of failure ! #
     #                                                              #
     ################################################################
-
-    - name: Push to GemFury
-      id: gemfury
-      if: (inputs.kind == 'lib' || steps.meta.outputs.is_distribution == 'true') && inputs.public != 'true' && env.PDM_PUBLISH_USERNAME != null
-      env:
-        PDM_PUBLISH_REPO: https://push.fury.io/ledger
-        PDM_PUBLISH_USERNAME: ${{ inputs.pypi-token || '' }}
-        PDM_PUBLISH_PASSWORD: "-" # tricks github actions YAML parser and PDM test for empty password
-        FORCE_COLOR: 'true'
-      run: |
-        : Push to GenFury
-        pdm publish --no-build
-      shell: bash
 
     - name: Push to our internal JFrog Artifactory
       id: artifactory
@@ -183,7 +169,6 @@ runs:
       with:
         clone: false
         version: ${{ env.REVISION }}
-        pypi-token: ${{ inputs.pypi-token }}
         github-token: ${{ inputs.github-token }}
         dgoss-args: ${{ inputs.dgoss-args }}
         name: ${{ inputs.docker-name }}
@@ -203,7 +188,6 @@ runs:
       with:
         clone: false
         version: ${{ env.REVISION }}
-        pypi-token: ${{ inputs.pypi-token }}
         github-token: ${{ inputs.github-token }}
         name: ${{ inputs.extra-docker }}
         suffix: ${{ inputs.extra-docker }}
@@ -223,7 +207,6 @@ runs:
       uses: LedgerHQ/actions/pdm/doc@main
       with:
         version: ${{ env.REVISION }}
-        pypi-token: ${{ inputs.pypi-token }}
         openapi: ${{ steps.meta.outputs.has_openapi == 'true' }}
         site: true
         init: false
@@ -351,30 +334,6 @@ runs:
         curl -X DELETE -u ${JFROG_USER}:${JFROG_TOKEN} ${JFROG_URL}/artifactory/${JFROG_DOCKER_REPOSITORY}/${{ inputs.extra-docker }}/${REVISION}
         IMAGE="${JFROG_DOMAIN}/${JFROG_DOCKER_REPOSITORY}/${{ inputs.extra-docker }}:${REVISION}@${{ steps.docker.outputs.digest }}"
         echo "🧹 Docker image \`${IMAGE}\` has been deleted" | tee -a $GITHUB_STEP_SUMMARY
-      shell: bash
-
-    - name: Cleanup GemFury
-      # Runs on release failure if package has been published to GemFury
-      if: failure() && steps.gemfury.outcome == 'success'
-      run: |
-        : Cleanup GemFury
-        # GemFury is unable to cleanup standard Python versions as it sees wheel+sdist
-        # as 2 Python versions, but doesn't provide distinct kind for them.
-        # So we delete by ID
-        # See:
-        #   - https://github.com/gemfury/cli/blob/main/api/yank.go
-        #   - https://github.com/gemfury/cli/blob/main/api/client.go
-        #   - https://github.com/gemfury/cli/blob/main/cli/yank.go
-        FURY=(curl --no-progress-meter -H "Accept: application/vnd.fury.v1" -H "Authorization: ${{ inputs.pypi-token }}" https://api.fury.io)
-        VERSIONS=$("${FURY[@]}/versions?name=${DIST}&version=${REVISION}")
-
-        echo "$VERSIONS" | jq -c ".[]" | while read i; do
-            filename=$(echo "$i" | jq -r .filename)
-            version_id=$(echo "$i" | jq -r .id)
-            package_id=$(echo "$i" | jq -r .package_id)
-            "${FURY[@]}/packages/${package_id}/versions/${version_id}" -X DELETE > /dev/null
-            echo "🧹 GemFury package \`${filename}\` have been deleted" | tee -a $GITHUB_STEP_SUMMARY
-        done
       shell: bash
 
     - name: Cleanup JFrog Artifactory

--- a/pdm/test/README.md
+++ b/pdm/test/README.md
@@ -29,7 +29,6 @@ See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
 | `python-version` | Python version to run the tests with | `""` | `false` |
-| `pypi-token` | ~~Private PyPI token (GemFury read)~~ **deprecated:** _use JFrog instead_ | `""` | `false` |
 | `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
 | `init` | Clone & sync | `true` | `false` |
 | `parameters` | Some extra parameters to pass to `pdm cover` | `""` | `false` |

--- a/pdm/test/action.yml
+++ b/pdm/test/action.yml
@@ -4,10 +4,6 @@ description: Execute test using `pdm` scripts
 inputs:
   python-version:
     description: Python version to run the tests with
-  pypi-token:
-    description: Private PyPI token (GemFury read)
-    required: false
-    deprecationMessage: use JFrog instead
   github-token:
     description: A Github token with proper permissions
     default: ${{ github.token }}
@@ -41,7 +37,6 @@ runs:
         python-version: ${{ inputs.python-version }}
         group: ${{ inputs.group }}
         exclude-group: ${{ inputs.exclude-group }}
-        pypi-token: ${{ inputs.pypi-token }}
         skip-dependencies: ${{ inputs.report-only }}
 
     - name: Compute unique matrix hashable ID


### PR DESCRIPTION
GemFury publication as well as the use of `pypi-token` has been deprecated for the past year. It's now time to drop it (and remove those warnings in the builds)