### PR TITLE
fix(pdm/docker): isolate GHA cache scope per image to prevent same repo concurrent builds cache poisoning

### DIFF
--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -157,8 +157,7 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=${{ steps.vars.outputs.name }}${{ inputs.suffix && format('-{0}', inputs.suffix) || '' }}
 
     - name: Install goss
       uses: e1himself/goss-installation-action@v1.3.0
@@ -209,8 +208,8 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=${{ steps.vars.outputs.name }}${{ inputs.suffix && format('-{0}', inputs.suffix) || '' }}
+        cache-to: type=gha,mode=max,scope=${{ steps.vars.outputs.name }}${{ inputs.suffix && format('-{0}', inputs.suffix) || '' }}
 
     - name: Attest Docker image for JFrog Artifactory
       if: env.JFROG_DOCKER_REPOSITORY


### PR DESCRIPTION
Multiple PRs building the same repo concurrently all wrote to the same default `buildkit` GHA cache scope, causing manifest overwrites and 10GB eviction pressure. Scope cache by image name (+ suffix) so each image gets an isolated bucket while still sharing cache across branches.

Also removes the redundant `cache-to` from the GOSS build step — the push step immediately overwrites it, so the GOSS write was pure waste.