### PR TITLE
ci(pdm/docker): scope GHA cache per repo and ref

### DIFF
--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -157,8 +157,8 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=pdm-docker-build-${{ github.repository }}-${{ github.ref_name }}
+        cache-to: type=gha,mode=max,scope=pdm-docker-build-${{ github.repository }}-${{ github.ref_name }}
 
     - name: Install goss
       uses: e1himself/goss-installation-action@v1.3.0
@@ -209,8 +209,8 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=pdm-docker-push-${{ github.repository }}-${{ github.ref_name }}
+        cache-to: type=gha,mode=max,scope=pdm-docker-push-${{ github.repository }}-${{ github.ref_name }}
 
     - name: Attest Docker image for JFrog Artifactory
       if: env.JFROG_DOCKER_REPOSITORY


### PR DESCRIPTION
## Summary
- The `pdm/docker` composite action exports/imports `type=gha` cache with no `scope=`, so every consumer repo and every branch shares a single namespace. With many consumers and frequent branch churn the cache thrashes (one job evicts another's layers) and occasionally pollutes across unrelated builds.
- Scope the cache per step (`build` vs `push`), per `github.repository`, and per `github.ref_name`. Each branch now reuses its own layers without colliding with others.

Mirrors the pattern applied in LedgerHQ/ledger-vault-api@99010a90cd18ca42168343b71c4c476cc8472bed. Surfaced via LES-Wallet CI investigation.

## Test plan
- [ ] Trigger CI on a consumer repo (e.g. les-wallet) and verify the docker step still hits the cache on a repeat run of the same branch.
- [ ] Verify a fresh branch starts with a cold cache and warms up on its second run.
- [ ] Verify two branches running concurrently no longer evict each other's cache (cache keys differ in the GHA cache UI).