### PR TITLE
fix(pdm/docker): switch GHA cache to mode=min to prevent build corruption

### DIFF
--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -158,7 +158,7 @@ runs:
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
         cache-from: type=gha,scope=pdm-docker-build-${{ github.repository }}-${{ github.ref_name }}
-        cache-to: type=gha,mode=max,scope=pdm-docker-build-${{ github.repository }}-${{ github.ref_name }}
+        cache-to: type=gha,mode=min,scope=pdm-docker-build-${{ github.repository }}-${{ github.ref_name }}
 
     - name: Install goss
       uses: e1himself/goss-installation-action@v1.3.0
@@ -210,7 +210,7 @@ runs:
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
         cache-from: type=gha,scope=pdm-docker-push-${{ github.repository }}-${{ github.ref_name }}
-        cache-to: type=gha,mode=max,scope=pdm-docker-push-${{ github.repository }}-${{ github.ref_name }}
+        cache-to: type=gha,mode=min,scope=pdm-docker-push-${{ github.repository }}-${{ github.ref_name }}
 
     - name: Attest Docker image for JFrog Artifactory
       if: env.JFROG_DOCKER_REPOSITORY


### PR DESCRIPTION
## Summary

- `mode=max` caches all intermediate Docker layers (including the builder stage) in GHA. When a build is cancelled mid-execution, partial layer blobs are written to GHA cache. The next run restores those blobs and reuses the corrupt builder stage, skipping `pdm dockerize` re-execution → `BadZipFile` on the 3–4 heaviest packages.
- `mode=min` only caches the final exported image layers. The builder stage (`pdm dockerize`) is never cached in GHA, so it always executes fresh and pulls packages cleanly from JFrog.
- Retains the per-repo/ref scope added in #481 — only removes `max`, keeps `scope=`.

## Root cause

`cache-to: type=gha,mode=max` exports every intermediate layer as it is produced. A cancelled build leaves partial blobs in GHA; the next build's `cache-from` restores them and skips the `RUN pdm dockerize` step entirely, serving up the corrupt cached layer.

`gh cache delete --all` was the current workaround — this fix makes it unnecessary.

## Test Plan

- [ ] Trigger a docker build on any repo using this action and cancel it mid-way while `pdm dockerize` is running
- [ ] Re-trigger — the next build should start fresh on the builder stage and complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)