### PR TITLE
ci: add descriptive error message on allure upload fail

### DIFF
--- a/allure/upload/action.yml
+++ b/allure/upload/action.yml
@@ -38,19 +38,58 @@ runs:
       id: upload
       run: |
         : Upload Allure results
-        response=$(\
-          curl -X POST '${{ inputs.url }}/api/result' \
-          --no-progress-meter \
-          --header  "accept: */*" \
-          --header  "Content-Type: multipart/form-data" \
-          --user '${{ inputs.username }}:${{ inputs.password }}' \
-          --form "allureResults=@allure.zip;type=application/x-zip-compressed" \
-        )
-        UUID=$(echo "${response}" | jq -r .uuid)
 
-        echo "response<<EOF" >> $GITHUB_OUTPUT
-        echo "${response}" >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
-        echo "uuid=${UUID}" >> $GITHUB_OUTPUT
-        echo "📊 Uploaded result ${UUID}"
+        ZIP_PATH="${{ github.workspace }}/allure.zip"
+        BODY_FILE="$(mktemp)"
+        trap 'rm -f "${BODY_FILE}"' EXIT
+
+        set +e
+        http_code=$(curl --silent --show-error \
+          --fail-with-body \
+          --user '${{ inputs.username }}:${{ inputs.password }}' \
+          --header 'accept: */*' \
+          --header 'Content-Type: multipart/form-data' \
+          --form "allureResults=@${ZIP_PATH};type=application/x-zip-compressed" \
+          --output "${BODY_FILE}" \
+          --write-out '%{http_code}' \
+          --max-time 300 \
+          --request POST '${{ inputs.url }}/api/result')
+        curl_rc=$?
+        set -e
+
+        response="$(cat "${BODY_FILE}")"
+
+        fail() {
+          local msg="$1"
+          local zip_size
+          zip_size=$(du -h "${ZIP_PATH}" 2>/dev/null | cut -f1 || echo "?")
+          echo "::error::${msg}"
+          echo "  URL:        ${{ inputs.url }}/api/result"
+          echo "  curl exit:  ${curl_rc}"
+          echo "  HTTP code:  ${http_code:-<none>}"
+          echo "  Zip size:   ${zip_size}"
+          echo "  Response body (first 2000 bytes):"
+          printf '%s\n' "${response}" | head -c 2000 | sed 's/^/    /'
+          echo
+          exit 1
+        }
+
+        if [[ "${curl_rc}" -ne 0 ]]; then
+          fail "Allure upload failed (curl exit ${curl_rc})"
+        fi
+
+        if [[ -z "${response}" ]]; then
+          fail "Allure server returned empty body (HTTP ${http_code})"
+        fi
+
+        UUID="$(printf '%s' "${response}" | jq -e -r .uuid 2>/dev/null)" \
+          || fail "Allure server reply was not JSON with .uuid (HTTP ${http_code})"
+
+        {
+          echo "response<<EOF"
+          printf '%s\n' "${response}"
+          echo "EOF"
+          echo "uuid=${UUID}"
+        } >> "${GITHUB_OUTPUT}"
+        echo "📊 Uploaded result ${UUID} (HTTP ${http_code})"
       shell: bash

--- a/allure/upload/action.yml
+++ b/allure/upload/action.yml
@@ -36,6 +36,10 @@ runs:
 
     - name: Upload Allure results
       id: upload
+      env:
+        ALLURE_URL: ${{ inputs.url }}
+        ALLURE_USERNAME: ${{ inputs.username }}
+        ALLURE_PASSWORD: ${{ inputs.password }}
       run: |
         : Upload Allure results
 
@@ -46,14 +50,13 @@ runs:
         set +e
         http_code=$(curl --silent --show-error \
           --fail-with-body \
-          --user '${{ inputs.username }}:${{ inputs.password }}' \
+          --user "${ALLURE_USERNAME}:${ALLURE_PASSWORD}" \
           --header 'accept: */*' \
-          --header 'Content-Type: multipart/form-data' \
           --form "allureResults=@${ZIP_PATH};type=application/x-zip-compressed" \
           --output "${BODY_FILE}" \
           --write-out '%{http_code}' \
           --max-time 300 \
-          --request POST '${{ inputs.url }}/api/result')
+          --request POST "${ALLURE_URL}/api/result")
         curl_rc=$?
         set -e
 
@@ -62,15 +65,17 @@ runs:
         fail() {
           local msg="$1"
           local zip_size
-          zip_size=$(du -h "${ZIP_PATH}" 2>/dev/null | cut -f1 || echo "?")
+          zip_size=$(du -h "${ZIP_PATH}" 2>/dev/null | cut -f1)
+          zip_size="${zip_size:-?}"
           echo "::error::${msg}"
-          echo "  URL:        ${{ inputs.url }}/api/result"
+          echo "  URL:        ${ALLURE_URL}/api/result"
           echo "  curl exit:  ${curl_rc}"
           echo "  HTTP code:  ${http_code:-<none>}"
           echo "  Zip size:   ${zip_size}"
-          echo "  Response body (first 2000 bytes):"
-          printf '%s\n' "${response}" | head -c 2000 | sed 's/^/    /'
-          echo
+          echo "  Response body: (if ACTIONS_STEP_DEBUG is 'true')"
+          while IFS= read -r line; do
+            echo "::debug::body: ${line}"
+          done <<< "${response:0:2000}"
           exit 1
         }
 

--- a/allure/upload/action.yml
+++ b/allure/upload/action.yml
@@ -72,23 +72,31 @@ runs:
           echo "  curl exit:  ${curl_rc}"
           echo "  HTTP code:  ${http_code:-<none>}"
           echo "  Zip size:   ${zip_size}"
+          local body="${response_pretty:-${response}}"
           echo "  Response body: (if ACTIONS_STEP_DEBUG is 'true')"
           while IFS= read -r line; do
             echo "::debug::body: ${line}"
-          done <<< "${response:0:2000}"
+          done <<< "${body:0:2000}"
           exit 1
         }
 
         if [[ "${curl_rc}" -ne 0 ]]; then
-          fail "Allure upload failed (curl exit ${curl_rc})"
+          fail "Allure upload failed"
         fi
 
         if [[ -z "${response}" ]]; then
-          fail "Allure server returned empty body (HTTP ${http_code})"
+          fail "Allure server returned empty body"
         fi
 
-        UUID="$(printf '%s' "${response}" | jq -e -r .uuid 2>/dev/null)" \
-          || fail "Allure server reply was not JSON with .uuid (HTTP ${http_code})"
+        response_pretty="$(printf '%s' "${response}" | jq . 2>/dev/null)" || response_pretty=""
+        if [[ -z "${response_pretty}" ]]; then
+          fail "Allure server reply was not valid JSON"
+        fi
+
+        UUID="$(printf '%s' "${response_pretty}" | jq -r '.uuid // empty')"
+        if [[ -z "${UUID}" ]]; then
+          fail "Allure server reply is JSON but has no .uuid field"
+        fi
 
         {
           echo "response<<EOF"


### PR DESCRIPTION
This PR updates the allure/upload composite action to make Allure upload failures easier to diagnose by capturing the HTTP status code and response body, and emitting a structured error report when the upload does not succeed.

Failing [upload](https://github.com/LedgerHQ/ledger-live/actions/runs/28148565296/job/83403560954)

<img width="539" height="183" alt="Screenshot 2026-06-25 at 12 05 29" src="https://github.com/user-attachments/assets/57f738c9-c5da-4a46-8503-8a890d2f651d" />



Passing [upload](https://github.com/LedgerHQ/ledger-live/actions/runs/28148603872/job/83364632438)


<img width="582" height="140" alt="Screenshot 2026-06-25 at 08 04 00" src="https://github.com/user-attachments/assets/e3f2270d-4a84-4da4-9c86-ef236a8db4bf" />

