### PR TITLE
perf(pdm): disable the GitHub Actions cache on self-hosted runners

### DIFF
--- a/pdm/docker/README.md
+++ b/pdm/docker/README.md
@@ -25,6 +25,12 @@ packages: write      # Docker image publication on ghcr
 
 See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/actions/tree/main/pdm#jfrog-artifactory)
 
+## Layer caching
+
+Docker layer caching (`type=gha`) is only enabled on GitHub-hosted runners:
+the GitHub Actions cache is served at ~2 MB/s from our self-hosted runners,
+so saving/restoring layers costs more than rebuilding them.
+
 ## Inputs
 
 | Input | Description | Default | Required |

--- a/pdm/docker/action.yml
+++ b/pdm/docker/action.yml
@@ -74,16 +74,6 @@ runs:
         username: ${{ env.JFROG_USER }}
         password: ${{ env.JFROG_TOKEN }}
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
-      with:
-        # Default behavior is to use the latest available version on the runner
-        # but the runner version is too old to handle GHA new cache
-        # cf. https://github.com/docker/build-push-action/issues/1345#issuecomment-2770572479
-        version: latest
-
     - name: Compute some variables
       id: vars
       run: |
@@ -102,6 +92,12 @@ runs:
         echo "has_docker=${HAS_DOCKER}" >> $GITHUB_OUTPUT
         [ -f "${GOSSPATH}/goss.yaml" ] && HAS_GOSS='true' || HAS_GOSS='false'
         echo "has_goss=${HAS_GOSS}" >> $GITHUB_OUTPUT
+
+        # The GitHub Actions cache is served at ~2 MB/s from our self-hosted runners:
+        # saving/restoring layers costs more than rebuilding them.
+        [ "${RUNNER_ENVIRONMENT}" = "github-hosted" ] && USE_GHA_CACHE='true' || USE_GHA_CACHE='false'
+        echo "use_gha_cache=${USE_GHA_CACHE}" >> $GITHUB_OUTPUT
+
         echo "images<<EOF" >> $GITHUB_OUTPUT
         if [ -n "${JFROG_DOCKER_REPOSITORY}" ]; then
           JFROG_IMAGE=${JFROG_DOMAIN}/${JFROG_DOCKER_REPOSITORY}/${NAME}
@@ -118,6 +114,17 @@ runs:
         fi
 
       shell: bash
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+      with:
+        # Default behavior is to use the latest available version on the runner
+        # but the runner version is too old to handle GHA new cache
+        # cf. https://github.com/docker/build-push-action/issues/1345#issuecomment-2770572479
+        # Only needed when the GHA cache is actually used, downloading it is pure overhead otherwise.
+        version: ${{ steps.vars.outputs.use_gha_cache == 'true' && 'latest' || '' }}
 
     - name: Compute docker metadata
       id: meta
@@ -157,8 +164,8 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
-        cache-from: type=gha,scope=pdm-docker-build-${{ github.repository }}-${{ github.ref_name }}
-        cache-to: type=gha,mode=min,scope=pdm-docker-build-${{ github.repository }}-${{ github.ref_name }}
+        cache-from: ${{ steps.vars.outputs.use_gha_cache == 'true' && format('type=gha,scope=pdm-docker-build-{0}-{1}', github.repository, github.ref_name) || '' }}
+        cache-to: ${{ steps.vars.outputs.use_gha_cache == 'true' && format('type=gha,mode=min,scope=pdm-docker-build-{0}-{1}', github.repository, github.ref_name) || '' }}
 
     - name: Install goss
       uses: e1himself/goss-installation-action@v1.3.0
@@ -209,8 +216,8 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
-        cache-from: type=gha,scope=pdm-docker-push-${{ github.repository }}-${{ github.ref_name }}
-        cache-to: type=gha,mode=min,scope=pdm-docker-push-${{ github.repository }}-${{ github.ref_name }}
+        cache-from: ${{ steps.vars.outputs.use_gha_cache == 'true' && format('type=gha,scope=pdm-docker-push-{0}-{1}', github.repository, github.ref_name) || '' }}
+        cache-to: ${{ steps.vars.outputs.use_gha_cache == 'true' && format('type=gha,mode=min,scope=pdm-docker-push-{0}-{1}', github.repository, github.ref_name) || '' }}
 
     - name: Attest Docker image for JFrog Artifactory
       if: env.JFROG_DOCKER_REPOSITORY

--- a/pdm/init/README.md
+++ b/pdm/init/README.md
@@ -58,7 +58,7 @@ See [the shared documentation on JFrog Artifactory](https://github.com/LedgerHQ/
 | `history` | Fetch the full history | `false` | `false` |
 | `github-token` | A Github token with proper permissions | `${{ github.token }}` | `false` |
 | `skip-dependencies` | Skip dependencies installation | `""` | `false` |
-| `cache` | Cache the dependencies (only used when dependencies are installed) | `true` | `false` |
+| `cache` | Cache the dependencies (only used when dependencies are installed, and ignored on self-hosted runners where the GitHub Actions cache is slower than fetching from JFrog) | `true` | `false` |
 
 ## Environment variables
 

--- a/pdm/init/action.yml
+++ b/pdm/init/action.yml
@@ -31,7 +31,9 @@ inputs:
   skip-dependencies:
     description: Skip dependencies installation
   cache:
-    description: Cache the dependencies (only used when dependencies are installed)
+    description: >-
+      Cache the dependencies (only used when dependencies are installed,
+      and ignored on self-hosted runners where the GitHub Actions cache is slower than fetching from JFrog)
     default: 'true'
 
 outputs:
@@ -145,12 +147,14 @@ runs:
       uses: pdm-project/setup-pdm@v4.5
       with:
         python-version: ${{ inputs.python-version }}
-        cache: ${{ inputs.cache }}
+        # The GitHub Actions cache is served at ~2 MB/s from our self-hosted runners,
+        # making it slower than fetching from JFrog, so it is only enabled on GitHub-hosted ones.
+        cache: ${{ inputs.cache == 'true' && runner.environment == 'github-hosted' }}
         cache-dependency-path: ${{ inputs.working-directory }}/pdm.lock
 
     # If `uv` is enabled, we install it first and then we use it to install python and pdm as it is way faster.
-    # Caching is explicitly disabled: the GitHub Actions cache is served at ~2 MB/s from our self-hosted
-    # runners and `setup-uv` prunes the wheel archives anyway, so it measured no gain over fetching from JFrog.
+    # Caching is explicitly disabled: on top of the slow self-hosted cache described above,
+    # `setup-uv` prunes the wheel archives anyway, so it measured no gain over fetching from JFrog.
     - name: Install uv
       if: steps.detect.outputs.use_uv == 'true'
       uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
On our self-hosted runners, the GitHub Actions cache is served at ~2 MB/s. Saving and restoring entries consistently costs more time than the work they are supposed to avoid.

This makes the GHA-backed caches of the `pdm` actions conditional on `runner.environment`:

- `pdm/docker`: the `type=gha` Docker layer cache (build and push steps). The `buildx` version pin follows the same condition since it only exists to support the new GHA cache protocol.
- `pdm/init`: the `setup-pdm` dependency cache, aligning the `pdm` path with the `uv` one where caching was already disabled.

GitHub-hosted runners keep the exact same behaviour, so no action input was added: the switch is fully automatic.